### PR TITLE
More vivid color for "mark" tag

### DIFF
--- a/public/stylesheets/devstyle.css
+++ b/public/stylesheets/devstyle.css
@@ -2,7 +2,6 @@ body {
   padding: 0px;
   padding-top: 50px;
   font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
-  
 
   background-color:  #d85050;
   

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -7,3 +7,7 @@ body {
 a {
   color: #00B7FF;
 }
+
+mark {
+  background-color: #FFF8C6;  /* Salmon Chiffon */
+}


### PR DESCRIPTION
Before:
![osmbc-mark-before](https://cloud.githubusercontent.com/assets/957501/11046696/9de753ba-870d-11e5-9a6f-bfcf8f916856.png)

After:
![osmbc-mark-after](https://cloud.githubusercontent.com/assets/957501/11046708/a7c335fc-870d-11e5-9aab-4b5175469f4a.png)

