### PR TITLE
Remove double "//" from languageflags.yaml

### DIFF
--- a/data/languageflags.yaml
+++ b/data/languageflags.yaml
@@ -1,9 +1,9 @@
-Japanisch: http://blog.openstreetmap.de/wp-uploads//2015/10/jp.svg
-Französisch: http://blog.openstreetmap.de/wp-uploads//2015/01/fr.svg
-Spanisch: http://blog.openstreetmap.de/wp-uploads//2015/01/es.svg
-Tschechisch: http://blog.openstreetmap.de/wp-uploads//2015/01/cz.svg
-Russisch: http://blog.openstreetmap.de/wp-uploads//2015/07/ru.svg
-Rumänisch: http://blog.openstreetmap.de/wp-uploads//2015/10/ro.svg
-Niederländisch: http://blog.openstreetmap.de/wp-uploads//2015/07/nl.svg
-Brasilianisches Portugiesisch: http://blog.openstreetmap.de/wp-uploads//2015/01/pt-br.svg
-Polish: http://blog.openstreetmap.de/wp-uploads//2015/10/pl.svg
+Japanisch: http://blog.openstreetmap.de/wp-uploads/2015/10/jp.svg
+Französisch: http://blog.openstreetmap.de/wp-uploads/2015/01/fr.svg
+Spanisch: http://blog.openstreetmap.de/wp-uploads/2015/01/es.svg
+Tschechisch: http://blog.openstreetmap.de/wp-uploads/2015/01/cz.svg
+Russisch: http://blog.openstreetmap.de/wp-uploads/2015/07/ru.svg
+Rumänisch: http://blog.openstreetmap.de/wp-uploads/2015/10/ro.svg
+Niederländisch: http://blog.openstreetmap.de/wp-uploads/2015/07/nl.svg
+Brasilianisches Portugiesisch: http://blog.openstreetmap.de/wp-uploads/2015/01/pt-br.svg
+Polish: http://blog.openstreetmap.de/wp-uploads/2015/10/pl.svg


### PR DESCRIPTION
The double "//" does not break anything and does not cause a redirect, so they are not a real problem, but it's still more correct without them :-).