### PR TITLE
consider only completed reviews, fixes #995

### DIFF
--- a/model/blog.js
+++ b/model/blog.js
@@ -110,7 +110,7 @@ Blog.prototype.getClosedReviewCount = function getClosedreviewCount(lang) {
   }
   const users = new Set();
   for (const review of self[rc]) {
-    if (review.text !== "startreview") users.add(review.user);
+    if ((review.text !== "startreview") && (review.text !== "reviewing...")) users.add(review.user);
   }
   return users.size;
 };

--- a/views/blog/blog_edit.pug
+++ b/views/blog/blog_edit.pug
@@ -126,7 +126,7 @@ block content
               td
                 if (!blog["close" + lang] && blog["reviewComment"+lang] && blog["reviewComment"+lang].length>0)
                   each val in blog["reviewComment"+lang]
-                    if (val.text != "startreview")
+                    if ((val.text != "startreview") && (val.text != "reviewing..."))
                       span.badge.small-margin(class="osmbclabel-reviewblog")=val.user
               //- Download Column
               td


### PR DESCRIPTION
added additional condition to consider reviews: reviews in progress are ignored.
additional situations like deleted reviews might be relevant, too?
did not adapt tests.