### PR TITLE
show translation links for all active languages

### DIFF
--- a/public/javascripts/article_view.js
+++ b/public/javascripts/article_view.js
@@ -486,16 +486,10 @@ function onchangeCollection() {
     if (window.articleReferences[link] && (window.articleReferences[link]).length > 0) {
       result += '<a class="badge badge-danger" href="' + link + '" target="_blank" >' + linkShortener(link) + " #(Check for Doublette)</a>\n";
     } else result += '<a class="badge badge-secondary" href="' + link + '" target="_blank" >' + linkShortener(link) + "</a>\n";
-    result += " " + generateGoogleTranslateLink(link, window.leftLang);
-    if (window.rightLang !== "--" && window.rightLang !== "") {
-      result += " " + generateGoogleTranslateLink(link, window.rightLang);
-    }
-    if (window.lang3 !== "--" && window.lang3 !== "") {
-      result += " " + generateGoogleTranslateLink(link, window.lang3);
-    }
-    if (window.lang4 !== "--" && window.lang4 !== "") {
-      result += " " + generateGoogleTranslateLink(link, window.lang4);
-    }
+
+    window.userLanguages.forEach(function(lang) {
+      result += " " + generateGoogleTranslateLink(link, lang);
+    });
 
     result += "<br>\n";
   }

--- a/views/article/article_mixin.pug
+++ b/views/article/article_mixin.pug
@@ -181,6 +181,7 @@ block append scripts_to_execute
     rightLang = "!{params.right_lang}";
     lang3 = "!{params.lang3}";
     lang4 = "!{params.lang4}";
+    userLanguages =  JSON.parse('!{JSON.stringify(layout.user.langArray)}');
     blogStartDate = '!{ (blog) ? blog.startDate : new Date().toISOString()}'
     translationServices = JSON.parse('!{JSON.stringify(translationServices)}');
     urlWoErrorWhileEdit = JSON.parse('!{JSON.stringify(urlWoErrorWhileEdit)}');


### PR DESCRIPTION
With this pull request, when more than four languages are selected, translation links are proposed for all selected additional languages. (currently, only the first four languages are present, see screenshot below)

![image](https://github.com/TheFive/osmbc/assets/34400929/4d445f80-c0f2-4fdd-9e53-3caf23a5cb66)

Please verify tests are passing and this change is compatible with legacy users (not using the language array)