### PR TITLE
Bugfix/heatmap typo

### DIFF
--- a/views/user.pug
+++ b/views/user.pug
@@ -209,7 +209,7 @@ block append scripts_to_execute
     $("#heatmap").github_graph({
       data:heatmapData,
       startDate: startDate,
-      texts: ["changes","change"],
+      texts: ["change","changes"],
       color:[
          "#218380", "#268583", "#2A8885", "#2F8A88", "#338D8A", "#388F8D", "#3C928F", "#419492", "#469795", "#4A9997",
          "#4F9C9A", "#539E9C", "#58A19F", "#5CA3A1", "#61A6A4", "#66A8A7", "#6AABA9", "#6FADAC", "#73B0AE", "#78B2B1",


### PR DESCRIPTION
singular and plural for changes were reversed for user heatmaps:
![image](https://github.com/TheFive/osmbc/assets/34400929/8937cffd-fbd1-41d5-a737-8638395520b0)

This small change fixes this:
![image](https://github.com/TheFive/osmbc/assets/34400929/04897404-737d-4fa5-8680-e01208a10a32)
