### PR TITLE
Bugfix/title image dimensions

### DIFF
--- a/render/BlogRenderer.js
+++ b/render/BlogRenderer.js
@@ -97,8 +97,8 @@ class HtmlRenderer {
           if (width > 0) {
             liON = liON.replace("##width##", width);
           } else {
-            liON = '<div style="width: 800px" class="wp-caption alignnone"> \n';
-            text = text.replace("></p>", ' width="800"></p>');
+            liON = '<div style="width: 810px" class="wp-caption alignnone"> \n';
+            text = text.replace("></p>", ' width="800" height="500"></p>');
           }
         }
         text = text.replace('alt=""', 'alt="lead picture"');

--- a/render/BlogRenderer.js
+++ b/render/BlogRenderer.js
@@ -97,8 +97,8 @@ class HtmlRenderer {
           if (width > 0) {
             liON = liON.replace("##width##", width);
           } else {
-            liON = '<div class="wp-caption alignnone"> \n';
-            text = text.replace("></p>", ' width="555"></p>');
+            liON = '<div style="width: 800px" class="wp-caption alignnone"> \n';
+            text = text.replace("></p>", ' width="800"></p>');
           }
         }
         text = text.replace('alt=""', 'alt="lead picture"');


### PR DESCRIPTION
this is a tiny extension to #976
Weekly 713 showed that the added dimensions were not sufficient for social media previews. A calendar icon was shown instead.
So this pull request...
... increases the fallback image dimension to a width of 1111px
... also adds this to the div of the title image