### PR TITLE
Remove space from start of link, and fix spelling ("Goto" → "Go to")

### DIFF
--- a/test/uc.access/UnkownGuestStartPage.html
+++ b/test/uc.access/UnkownGuestStartPage.html
@@ -51,8 +51,8 @@
     <div class="container-fluid">
       <p>
         </p><div class="alert alert-danger text-center" id="mailalert" style="height: 200px; font-size: 40px;">
-          <p>Please enter your email to receive comments and feedback here:</p>
-          <p><a class="alert-link" href="/usert/self"> Goto User Configuration</a></p>
+          <span>Please enter your email to receive comments and feedback here:</span>
+          <span> <a class="alert-link" href="/usert/self">Go to User Configuration</a></span>
         </div>
       <p></p>
       <p>

--- a/test/user/home missing email.html
+++ b/test/user/home missing email.html
@@ -61,8 +61,8 @@
     <div class="container-fluid">
       <p></p>
       <div class="alert alert-danger text-center" id="mailalert" style="overflow: hidden; height: 95.8992px; font-size: 15.1686px;">
-        <p>Please enter your email to receive comments and feedback here:</p>
-        <p><a class="alert-link" href="/usert/self"> Goto User Configuration</a></p>
+        <span>Please enter your email to receive comments and feedback here:</span>
+        <span> <a class="alert-link" href="/usert/self">Go to User Configuration</a></span>
       </div>
       <p></p>
       <p>

--- a/test/user/home missing verification.html
+++ b/test/user/home missing verification.html
@@ -67,8 +67,8 @@
       <p>
       </p>
       <div class="alert alert-danger text-center" id="mailalert" style="height: 200px; font-size: 40px;">
-        <p>Waiting for email verification, have a look at the email with the title '[OSMBC] Welcome to OSMBC' in your inbox.</p>
-        <p><a class="alert-link" href="/usert/self"> Goto User Configuration</a></p>
+        <span>Waiting for email verification, have a look at the email with the title '[OSMBC] Welcome to OSMBC' in your inbox.</span>
+        <span> <a class="alert-link" href="/usert/self">Go to User Configuration</a></span>
       </div>
       <p></p>
       <p>

--- a/test/user/uc.user.js
+++ b/test/user/uc.user.js
@@ -205,7 +205,7 @@ describe("views/user", function() {
 
 
     // Check Homepage for Missing Email Warning
-    should(await osmbcApp.getMainPage().getMailAlertText()).eql("Please enter your email to receive comments and feedback here: Goto User Configuration");
+    should(await osmbcApp.getMainPage().getMailAlertText()).eql("Please enter your email to receive comments and feedback here: Go to User Configuration");
 
     await driver.get(osmbcLink("/usert/1"));
     const userPage = osmbcApp.getUserPage();
@@ -225,7 +225,7 @@ describe("views/user", function() {
     // Check Homepage for Missing Verification Warning
     await osmbcApp.openMainPage();
 
-    should(await osmbcApp.getMainPage().getMailAlertText()).eql("Waiting for email verification, have a look at the email with the title '[OSMBC] Welcome to OSMBC' in your inbox. Goto User Configuration");
+    should(await osmbcApp.getMainPage().getMailAlertText()).eql("Waiting for email verification, have a look at the email with the title '[OSMBC] Welcome to OSMBC' in your inbox. Go to User Configuration");
 
     await driver.get(link);
     result = await userModule.findById(1);

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -149,13 +149,15 @@ block all
             div.alert.alert-danger.text-center#mailalert
               span="Waiting for email verification, have a look at the email with the title '[OSMBC] Welcome to OSMBC' in your inbox."
               span
-                a.alert-link(href=layout.htmlroot+"/usert/self")=" Goto User Configuration"
+                | 
+                a.alert-link(href=layout.htmlroot+"/usert/self")="Go to User Configuration"
         if (layout && layout.user && layout.user && !layout.user.email && !layout.user.emailInvalidation)
           p
             div.alert.alert-danger.text-center#mailalert
               span="Please enter your email to receive comments and feedback here:"
               span
-                a.alert-link(href=layout.htmlroot + "/usert/self")=" Goto User Configuration"
+                | 
+                a.alert-link(href=layout.htmlroot + "/usert/self")="Go to User Configuration"
 
         p
          block content


### PR DESCRIPTION
When first signing up, as the email is not yet confirmed, a warning message is shown to the user, containing a link labeled "Goto User Configuration". This link has a slight spelling issue (it should say "Go to" instead of "Goto"), but it also has the issue that the preceding space is contained within it, which makes the rendering a little awkward — when hovering the link, the space gets underlined as well:

![image](https://github.com/user-attachments/assets/7f913708-9185-4634-992a-58511c3c6961)

This change aims to fix both issues. I also edited the tests accordingly, although I suspect they were not being executed anyway because the HTML structure did not match the .pug file (they were using `<p>` tags when a `<span>` was meant to be).

Happy to make any adjustment that may be required!