### PR TITLE
Add outstanding-export API endpoint for bulk blog delivery

### DIFF
--- a/API.md
+++ b/API.md
@@ -190,12 +190,20 @@ are unaffected.
 |---|---|---|
 | `exportProfile` | yes | Must be a profile with a `pathTemplate` configured (e.g. `HugoDownload`, `MarkdownDownload` in the test config) — profiles without one (plain HTML export profiles) can't produce a bundle and are rejected. |
 | `lang` | no | A single language code, or `ALL` (default: all configured languages). Each blog is only included for languages where it is actually closed and not yet exported. |
+| `minBlogNumber` | no | Inclusive lower bound on the WN number (e.g. `256` for `WN256`). Non-negative integer. |
+| `maxBlogNumber` | no | Inclusive upper bound on the WN number. Non-negative integer; rejected with `422` if smaller than `minBlogNumber`. |
 | `dryRun` | no | `true` → return a JSON preview instead of building/downloading/marking anything (see below). |
+
+`minBlogNumber`/`maxBlogNumber` exist so a consumer can page through a large
+backlog (there can be hundreds of outstanding blogs on a first run) instead
+of getting everything in one response, e.g. `minBlogNumber=1&maxBlogNumber=100`,
+then `minBlogNumber=101&maxBlogNumber=200`, and so on.
 
 ### What counts as "outstanding"
 
 A blog+language is included if **all** of:
 - the blog is a WeeklyNote blog (name matches `WN<number>`)
+- its WN number is within `[minBlogNumber, maxBlogNumber]`, if given
 - `blog.status` is `edit` or `closed` (not `open`, not archived states)
 - `close{LANG}` is `true` for that language
 - `blog.exportedBy[exportProfile][lang]` is **not** set
@@ -274,6 +282,8 @@ across multiple server instances/processes.
   ```json
   {
     "exportProfile": "HugoDownload",
+    "minBlogNumber": null,
+    "maxBlogNumber": null,
     "count": 2,
     "blogs": [
       { "name": "WN1234", "langs": ["DE"] },
@@ -281,14 +291,17 @@ across multiple server instances/processes.
     ]
   }
   ```
-  No side effects — nothing is rendered, bundled, or marked.
+  `minBlogNumber`/`maxBlogNumber` echo back the applied bounds (`null` if not
+  given). No side effects — nothing is rendered, bundled, or marked.
 - `200` (empty ZIP) — only if the profile sets `noContentBehavior:
   "emptyZip"` and nothing is outstanding.
 - `404` — nothing outstanding and the profile's `noContentBehavior` is
   unset or `"404"` (the default): `No blogs available for outstanding
   export`.
 - `409` — see Concurrency above.
-- `422` — missing/unknown `exportProfile`, or profile has no `pathTemplate`.
+- `422` — missing/unknown `exportProfile`, profile has no `pathTemplate`,
+  `minBlogNumber`/`maxBlogNumber` isn't a non-negative integer, or
+  `minBlogNumber` is greater than `maxBlogNumber`.
 
 ### Example
 
@@ -296,7 +309,13 @@ across multiple server instances/processes.
 # See what would be exported, without downloading or marking anything
 curl "https://<host>/api/blogPreviewDownload/<apiKey>/outstanding?exportProfile=HugoDownload&dryRun=true"
 
-# Actually pull it (and mark everything included as delivered)
+# Page through a large backlog in chunks of 100 WN numbers
+curl -o outstanding-1.zip \
+  "https://<host>/api/blogPreviewDownload/<apiKey>/outstanding?exportProfile=HugoDownload&minBlogNumber=1&maxBlogNumber=100"
+curl -o outstanding-2.zip \
+  "https://<host>/api/blogPreviewDownload/<apiKey>/outstanding?exportProfile=HugoDownload&minBlogNumber=101&maxBlogNumber=200"
+
+# Actually pull it all (and mark everything included as delivered)
 curl -o outstanding.zip \
   "https://<host>/api/blogPreviewDownload/<apiKey>/outstanding?exportProfile=HugoDownload"
 ```

--- a/API.md
+++ b/API.md
@@ -1,0 +1,287 @@
+# OSMBC Public API
+
+This document describes the public, API-key-secured HTTP API exposed by
+[routes/api.js](routes/api.js). It is separate from the session/cookie-based
+web UI. All endpoints below are mounted under:
+
+```
+<htmlroot>/api
+```
+
+`<htmlroot>` is the `htmlroot` value from `config.<env>.yaml` (often empty).
+Examples in this document use `/api/...` directly.
+
+## Authentication
+
+Every endpoint takes an `:apiKey` path segment. It is checked in one of two
+ways (see `checkApiKey` in `routes/api.js`):
+
+1. **Shared/label key** — configured under `apiKeys` in `config.<env>.yaml`:
+   ```yaml
+   apiKeys:
+     testapikey: monitor
+     testapikey.TBC: TBC Collections
+   ```
+   The value (`monitor`, `TBC Collections`, ...) is a human-readable label,
+   not a secret — it identifies *what the key is for*, not *who* is calling.
+   Requests authenticated this way do not carry a real OSM user identity.
+
+2. **Personal key** — a key stored on a `usert` record (`data->>'apiKey'`,
+   manageable per-user in the web UI). Requests authenticated this way carry
+   the calling user's identity (`OSMUser`).
+
+An unknown key returns:
+
+```
+HTTP 401
+Not Authorised
+```
+
+### Error response format
+
+Handlers that set `err.type = "API"` (all endpoints below) get their error
+returned as **plain text**, with the given HTTP status:
+
+```
+HTTP <status>
+<err.message>
+```
+
+There is no JSON error envelope. Successful responses vary by endpoint (see
+below) — most are plain text or a binary/file download; the `outstanding`
+endpoint's dry-run mode is the one JSON response in this API.
+
+---
+
+## `GET /api/monitor/:apiKey`
+
+Liveness check. Always responds `200 OK` with body `OK` if the process is up
+and the API key is valid (any configured key works, shared or personal).
+
+Used by uptime/monitoring tooling.
+
+---
+
+## `GET /api/monitorPostgres/:apiKey`
+
+Liveness check including a Postgres round-trip (`SELECT` on the `usert`
+table).
+
+**Note:** this endpoint always answers with `HTTP 200`, even when Postgres is
+unreachable — the *body* differentiates:
+
+```
+OK               → Postgres reachable
+Postgres Error   → Postgres query failed
+```
+
+Monitoring integrations must check the response **body**, not just the HTTP
+status.
+
+---
+
+## `POST /api/collectArticle/:apiKey`
+
+Collects a new article into the `TBC` ("to be categorized") blog. Intended
+for programmatic/bot submission (e.g. browser extensions, scripts) — compare
+with `GET /api/collect/:apiKey` below, which is the lightweight GET variant
+for bookmarklets.
+
+### Body (`application/x-www-form-urlencoded` or JSON)
+
+| Field | Required | Description |
+|---|---|---|
+| `collection` | yes | Free text / URL(s) to collect. If `title` is omitted, the first URL found inside `collection` is fetched to auto-derive a title. |
+| `OSMUser` | one of `OSMUser`/`email` | Existing OSMBC user name to attribute the collection to. |
+| `email` | one of `OSMUser`/`email` | Alternative to `OSMUser`; resolved to a user via `email`. |
+| `title` | no | Article title. Auto-fetched from the first URL in `collection` if omitted (falls back to `"NOT GIVEN"` if no URL is found). |
+| `categoryEN` | no | Defaults to `"-- no category yet --"`. |
+| `markdown{LANG}` | no | Per-language markdown body, e.g. `markdownDE`, `markdownEN` (one field per configured language). |
+| `markdown` | no | Un-suffixed markdown; assigned to the resolved user's own language. |
+
+### Responses
+
+- `200` — plain text: `Article Collected in TBC.`
+- `422` — missing `collection`, or neither `OSMUser` nor `email` resolves to
+  an existing user (`Missing Collection`, `No OSMUser && EMail given`, `No
+  OSMUser given, could not resolve email address`).
+
+---
+
+## `GET /api/collect/:apiKey`
+
+Lightweight GET variant of article collection, meant for simple integrations
+(bookmarklets, `<a href>` links) where a form POST isn't practical.
+
+**Requires a personal API key** (must resolve to `req.user`). A shared/label
+key passes `checkApiKey` (which doesn't distinguish per-route), but this
+handler then rejects it — since there is no `OSMUser` to attribute the
+collection to — with a generic **HTML** error page and `HTTP 500` (this
+error isn't marked `type: "API"`, so it doesn't get the plain-text format
+described above). Use a personal key here, not a shared one.
+
+### Query parameters
+
+| Param | Required | Description |
+|---|---|---|
+| `collection` | yes | Same semantics as in `collectArticle`. |
+| `title` | no | Same as `collectArticle`. |
+
+### Responses
+
+- `200` — plain text: the full URL of the newly created article
+  (`<config.url><htmlroot>/article/<id>`). Also sets
+  `Access-Control-Allow-Origin: *` (safe to call cross-origin from a
+  bookmarklet).
+- `422` — `Missing Collection` if `collection` is absent.
+
+---
+
+## `GET /api/blogPreviewDownload/:apiKey/:blog_id`
+
+Renders and downloads a **single** blog using a configured export profile.
+This is the same rendering path the web UI's "Export" menu uses.
+
+### Route parameter
+
+`:blog_id` accepts (resolved by `findBlogByRouteId`, see `model/blog.js`):
+
+| Value | Resolves to |
+|---|---|
+| a DB id (number) | that blog |
+| a blog name, e.g. `WN1234` | that blog |
+| `current` | the currently open (`status: edit`) WeeklyNote blog with the latest `startDate`. **Not** the same as the `outstanding` endpoint below — see note there. |
+| `TBC` | the virtual "to be categorized" collection blog |
+
+Unknown/unresolvable `blog_id` → `404 Blog not found`.
+
+### Query parameters
+
+| Param | Required | Description |
+|---|---|---|
+| `exportProfile` | yes | Name of an entry under `ExportProfiles` in `config.<env>.yaml` (e.g. `OsmbcDownload`, `HugoDownload`, `MarkdownDownload` — profile names/renderers are deployment-specific config, check your `config.<env>.yaml`). |
+| `lang` | no | A configured language code (e.g. `DE`, `EN`, ...), or `ALL`. Defaults to `EN` if omitted or invalid. `ALL` with a Markdown/Hugo-style profile exports every configured language; `ALL` with an HTML profile exports only the languages currently marked `close{LANG}: true`. |
+
+### Responses
+
+- `200` — the rendered content, with `content-type` and filename set from
+  the profile (`fileNameTemplate`). Single language + HTML profile ⇒ raw
+  HTML body; multiple languages / zip `bundleMode` ⇒ a `.zip` stream.
+- `422` — `Missing exportProfile`, or `Unknown export profile: <name>`.
+
+---
+
+## `GET /api/blogPreviewDownload/:apiKey/outstanding`
+
+Bulk export: bundles **every** WeeklyNote blog that is closed for the
+requested language(s) but not yet delivered under the given export profile,
+into a single ZIP — intended for pipelines (e.g. a Hugo static-site build)
+that pull "whatever is new since last time" rather than one blog at a time.
+
+**Not the same as `current` above.** `current` (in the single-blog route)
+always means "the one currently-open blog". `outstanding` means "every
+closed-but-undelivered blog, of which there can be zero, one, or several".
+They are deliberately different endpoints so existing `current` consumers
+are unaffected.
+
+### Query parameters
+
+| Param | Required | Description |
+|---|---|---|
+| `exportProfile` | yes | Must be a profile with a `pathTemplate` configured (e.g. `HugoDownload`, `MarkdownDownload` in the test config) — profiles without one (plain HTML export profiles) can't produce a bundle and are rejected. |
+| `lang` | no | A single language code, or `ALL` (default: all configured languages). Each blog is only included for languages where it is actually closed and not yet exported. |
+| `dryRun` | no | `true` → return a JSON preview instead of building/downloading/marking anything (see below). |
+
+### What counts as "outstanding"
+
+A blog+language is included if **all** of:
+- the blog is a WeeklyNote blog (name matches `WN<number>`)
+- `blog.status` is `edit` or `closed` (not `open`, not archived states)
+- `close{LANG}` is `true` for that language
+- `blog.exportedBy[exportProfile][lang]` is **not** set
+
+### Side effects on success
+
+After the ZIP has been fully sent, each included blog+language is marked:
+
+```json
+"exportedBy": { "<exportProfile>": { "<LANG>": "<ISO timestamp>" } }
+```
+
+This is written as a normal blog change (via `setAndSave`), so it also
+produces a change-log entry (`property: "exportedBy"`), attributed to:
+- the calling user's `OSMUser`, for a personal API key
+- `"apikey:<label>"` (the configured label, not the secret key), for a
+  shared API key
+
+If a blog's language is reopened later (`close{LANG}` → `false`), its marker
+for that language is cleared and it becomes "outstanding" again. If a blog's
+`status` changes back to `edit`/`open`, **all** of its export markers are
+cleared.
+
+A marker failing to save for one blog does not affect the others — each is
+saved independently; a failure is only debug-logged server-side. That blog
+simply stays "outstanding" and is offered again on the next call (safer to
+re-deliver than to silently drop it).
+
+### Partial rendering failures
+
+If one blog fails to render (e.g. malformed content), it is **skipped**, not
+fatal to the request — the rest of the batch still gets bundled, downloaded
+and marked. Skipped items are listed in a response header:
+
+```
+X-Outstanding-Export-Warnings: WN1234:DE,WN1235:EN
+```
+
+(comma-separated `<blogName>:<lang>` pairs). Absent if nothing failed.
+
+### Concurrency
+
+Only one non-dry-run `outstanding` request per `exportProfile` may be in
+flight at a time (prevents two overlapping requests from re-delivering and
+double-marking the same blogs). A second concurrent request for the same
+profile gets:
+
+```
+HTTP 409
+Outstanding export for profile '<exportProfile>' is already in progress, please retry shortly
+```
+
+This is an **in-process** guard (kept in memory) — it does not coordinate
+across multiple server instances/processes.
+
+### Responses
+
+- `200` (ZIP) — `application/zip`, filename from `fileNameTemplate` (with
+  template placeholders resolved to `outstanding`) or `outstanding.zip`.
+- `200` (dry run, `dryRun=true`) — `application/json`:
+  ```json
+  {
+    "exportProfile": "HugoDownload",
+    "count": 2,
+    "blogs": [
+      { "name": "WN1234", "langs": ["DE"] },
+      { "name": "WN1235", "langs": ["DE", "EN"] }
+    ]
+  }
+  ```
+  No side effects — nothing is rendered, bundled, or marked.
+- `200` (empty ZIP) — only if the profile sets `noContentBehavior:
+  "emptyZip"` and nothing is outstanding.
+- `404` — nothing outstanding and the profile's `noContentBehavior` is
+  unset or `"404"` (the default): `No blogs available for outstanding
+  export`.
+- `409` — see Concurrency above.
+- `422` — missing/unknown `exportProfile`, or profile has no `pathTemplate`.
+
+### Example
+
+```bash
+# See what would be exported, without downloading or marking anything
+curl "https://<host>/api/blogPreviewDownload/<apiKey>/outstanding?exportProfile=HugoDownload&dryRun=true"
+
+# Actually pull it (and mark everything included as delivered)
+curl -o outstanding.zip \
+  "https://<host>/api/blogPreviewDownload/<apiKey>/outstanding?exportProfile=HugoDownload"
+```

--- a/API.md
+++ b/API.md
@@ -208,11 +208,26 @@ After the ZIP has been fully sent, each included blog+language is marked:
 "exportedBy": { "<exportProfile>": { "<LANG>": "<ISO timestamp>" } }
 ```
 
-This is written as a normal blog change (via `setAndSave`), so it also
-produces a change-log entry (`property: "exportedBy"`), attributed to:
-- the calling user's `OSMUser`, for a personal API key
-- `"apikey:<label>"` (the configured label, not the secret key), for a
-  shared API key
+This goes through the normal `setAndSave` mutation path (same as every
+other blog change), but does **not** appear in the blog's change history
+shown to editors and does **not** trigger the mail/Slack "blog changed"
+notifications a real editorial change would — see "Notifications" in
+`CLAUDE.md` for why: the Postgres change-log receiver is wrapped to skip
+purely operational fields like `exportedBy`, and the mail/Slack receivers
+already only react to an actual `status` change, which this never sets.
+Instead, it is recorded in a separate rotating text log file (see
+`notification/exportLogWriter.js`, config keys `exportlog_directory` /
+`exportlog_prefix` / `exportlog_dateformat`, same idea as the existing mail
+delivery log: an admin-readable operational record, not editorial content),
+as one JSON line per blog+lang:
+
+```json
+{"user": "apikey:hugoPipeline", "blog": "WN1234", "exportProfile": "HugoDownload", "lang": "DE", "timestamp": "2026-08-31T12:00:00.000Z"}
+```
+
+`user` is the calling user's `OSMUser` for a personal API key, or
+`"apikey:<label>"` (the configured label, not the secret key) for a shared
+API key.
 
 If a blog's language is reopened later (`close{LANG}` → `false`), its marker
 for that language is cleared and it becomes "outstanding" again. If a blog's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,9 @@ you're on. Task- or worktree-specific notes belong in `CLAUDE.local.md`
 - Export targets are defined under `ExportProfiles` in the config
   (HTML/WP, Markdown, Hugo — `renderer: HUGO`). OSMBC is meant to be the
   editorial source of truth; Hugo export is one of several render targets
-  generated from it, not a separate data source.
+  generated from it, not a separate data source. See
+  `docs/export-profiles.md` for the field-by-field meaning of a profile
+  entry, and `docs/API.md` for the caller-facing API that consumes it.
 
 ## Notifications (`setAndSave` → `messageCenter`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,41 @@ you're on. Task- or worktree-specific notes belong in `CLAUDE.local.md`
   editorial source of truth; Hugo export is one of several render targets
   generated from it, not a separate data source.
 
+## Notifications (`setAndSave` → `messageCenter`)
+
+- Every `setAndSave`/`closeBlog`/etc. mutation broadcasts the full `change`
+  object to **every** registered `messageCenter.global` receiver
+  (`notification/messageCenter.js`), via `updateBlog`/`updateArticle`/
+  `sendReviewStatus`/`sendCloseStatus`/`addComment`/`editComment`/`sendInfo`.
+  It is each receiver's own job to decide whether a given change is
+  relevant to it — the broadcaster does not filter anything itself.
+  Concretely today: `LogModuleReceiver` (Postgres `changes` log, wrapped in
+  a `FilterReceiver`), `ExportReceiver` (text-log for operational markers),
+  and, via `IteratorReceiver`, one `MailReceiver`/`SlackReceiver` instance
+  per interested channel/user.
+- `MessageCenter` calls every receiver method **unconditionally, with no
+  existence check** — a receiver that's missing one of the seven interface
+  methods (`sendInfo`, `updateArticle`, `updateBlog`, `sendReviewStatus`,
+  `sendCloseStatus`, `addComment`, `editComment`) throws as soon as that
+  event fires. Any new receiver must implement all seven (no-op stubs for
+  the irrelevant ones), e.g. `notification/exportReceiver.js`.
+- Relevance filtering is inconsistent by receiver, and that inconsistency
+  matters: `UserConfigFilter` (wrapping `MailReceiver` per user) checks
+  `change.status` before reacting; `LogModuleReceiver` on its own does
+  **not** filter at all — it logs whatever keys are present in `change`
+  unconditionally, so an unfiltered receiver turns every field change into
+  a Postgres row visible to editors. `notification/FilterReceiver.js` is
+  the generic, reusable wrapper for bolting a relevance predicate in front
+  of a receiver that doesn't already do its own filtering (formalizes what
+  `UserConfigFilter` did ad hoc) — see `notification/messageCenter.js` for
+  how it wraps `LogModuleReceiver` to skip purely operational fields (e.g.
+  `blog.exportedBy`, set by `Blog.prototype.markAsExported`).
+- Net effect: a field that should stay invisible to editors (not appear in
+  the change history, not trigger a mail/Slack "changed" notification)
+  should still be written via `setAndSave` like everything else — never by
+  reaching for a bare `save()` to dodge the broadcast — and instead get a
+  `FilterReceiver`-wrapped or self-filtering receiver that ignores it.
+
 ## Development workflow
 
 - Prefer `git worktree` for working on unrelated things in parallel (e.g.

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -200,6 +200,7 @@ ExportProfiles:
     bundleMode: zip
     pathTemplate: "##lang##/archives/##blogNumber-4-digits##"
     fileNameTemplate: "##blogName##"
+    noContentBehavior: "404"
     download: true
     guiEnabled: true
     guiLabel: Export All as Hugo (*.zip)
@@ -210,6 +211,7 @@ ExportProfiles:
     bundleMode: zip
     pathTemplate: "##lang##-##blogNumber-4-digits##"
     fileNameTemplate: "##blogName##"
+    noContentBehavior: "emptyZip"
     download: true
     guiEnabled: true
     guiLabel: Export All as Markdown (*.zip)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,7 +1,7 @@
 # OSMBC Public API
 
 This document describes the public, API-key-secured HTTP API exposed by
-[routes/api.js](routes/api.js). It is separate from the session/cookie-based
+[routes/api.js](../routes/api.js). It is separate from the session/cookie-based
 web UI. All endpoints below are mounted under:
 
 ```
@@ -10,6 +10,11 @@ web UI. All endpoints below are mounted under:
 
 `<htmlroot>` is the `htmlroot` value from `config.<env>.yaml` (often empty).
 Examples in this document use `/api/...` directly.
+
+For the full field-by-field meaning of an `ExportProfiles` entry itself
+(`renderer`, `pathTemplate`, `noContentBehavior`, the `gui*` menu fields,
+...), see [docs/export-profiles.md](export-profiles.md). This document only
+covers what a *caller* of the routes below needs to know.
 
 ## Authentication
 

--- a/docs/export-profiles.md
+++ b/docs/export-profiles.md
@@ -1,0 +1,67 @@
+# `ExportProfiles` configuration
+
+`ExportProfiles` is a top-level map in `config.<env>.yaml`. Each key is a
+profile name referenced by callers as the `exportProfile` value — in the web
+UI's "Export" menu ([routes/layout.js](../routes/layout.js)) and in the
+public API ([docs/API.md](API.md), `GET /api/blogPreviewDownload/...`).
+
+```yaml
+ExportProfiles:
+  HugoDownload:
+    renderer: HUGO
+    pathTemplate: "##lang##/archives/##blogNumber-4-digits##"
+    fileNameTemplate: "Hugo-##blogName##"
+    guiEnabled: true
+    guiLabel: Export All as Hugo (*.zip)
+    guiLangMode: all
+    guiOrder: 20
+    noContentBehavior: emptyZip
+```
+
+There is no schema validation — an unknown/misspelled field is silently
+ignored, and a required field that's missing usually only surfaces the first
+time that code path runs (see "Fields with no confirmed effect" below for a
+concrete case of the former).
+
+## Fields
+
+| Field | Used by | Meaning |
+|---|---|---|
+| `renderer` | `model/blog.js` (`buildPreviewExport`, single-blog and `outstanding` export) | Renderer type, e.g. `HTML`, `MARKDOWN`, `HUGO`. Defaults to `"HTML"` if omitted. |
+| `rendererOptions` | same | Passed through verbatim to the renderer (e.g. `{ target: "editor" }` / `{ target: "production" }` for `HTML`). |
+| `pathTemplate` | `model/blog.js`, `routes/api.js` (`outstanding`) | Path of each file **inside** a zip bundle. Placeholders: `##lang##`, `##blogNumber-4-digits##`. **Required** for the `outstanding` bulk-export endpoint — a profile without it is rejected with `422` before any blog is even looked up. Not required for the single-blog route. |
+| `fileNameTemplate` | `model/blog.js`, `routes/api.js` | Download filename. Placeholders: `##blogName##`, `##renderer##`, `##langList##`, `##blogNumber-4-digits##`. For `outstanding`, every placeholder is replaced with the literal string `outstanding` (there's no single blog to name it after), e.g. `"Hugo-##blogName##"` → `Hugo-outstanding.zip`. |
+| `noContentBehavior` | `routes/api.js` (`outstanding` only) | `"404"` (default, also applies if the field is absent) → HTTP 404 when nothing is outstanding. `"emptyZip"` → HTTP 200 with an empty zip instead. Has no effect on the single-blog route (there, an unresolvable blog is always `404`). |
+| `guiEnabled` | `routes/layout.js` | Must be `true` for the profile to appear in the web UI's export menu at all. Profiles used only via the API (no UI entry point) can safely omit or set this `false`. |
+| `guiLabel` | `routes/layout.js` | Menu label text. Falls back to the profile name if omitted. |
+| `guiLangMode` | `routes/layout.js`, `views/blog/blogheader.pug` | `"single"` (default) shows one menu entry per configured language; `"all"` shows one combined "all languages" entry. Purely a UI menu-shape switch — unrelated to the `outstanding` endpoint's own `lang=ALL` query param. |
+| `guiOrder` | `routes/layout.js` | Sort key for menu position (ascending); ties broken alphabetically by `guiLabel`. Defaults to `999` (sorts last) if omitted. |
+
+## Fields with no confirmed effect
+
+`bundleMode`, `includeLanguageMarkers`, and `download` appear in the
+repo's example config ([config.test.yaml](../config.test.yaml)) on most
+profiles, but as of this writing no `.js` code path reads
+`profileConfig.bundleMode`, `profileConfig.includeLanguageMarkers`, or
+`profileConfig.download` (confirmed via repo-wide grep). Whether a bundle
+becomes a raw file vs. a zip is actually decided by the renderer/language
+count at render time, not by a `bundleMode` config key; the export menu's
+`download=true` query flag is hardcoded in
+[views/blog/blogheader.pug](../views/blog/blogheader.pug), not sourced from
+the profile's `download` field.
+
+Treat these three as either dead config or reserved for a renderer-internal
+code path that wasn't covered by this audit — don't rely on them to change
+behavior, and don't copy them into a new profile assuming they do something.
+If you find the code path that does consume one of them, please update this
+table instead of re-guessing next time.
+
+## See also
+
+- [docs/API.md](API.md) — caller-facing documentation of the two routes that
+  consume `ExportProfiles` (`blogPreviewDownload/:blog_id` and
+  `blogPreviewDownload/outstanding`), including the full `noContentBehavior`
+  behavior, response codes, and worked `curl` examples.
+- [model/blog.js](../model/blog.js) `buildPreviewExport()` JSDoc — the
+  lowest-level renderer contract (`renderer`/`rendererOptions`/
+  `pathTemplate`/`fileNameTemplate` and their placeholder syntax).

--- a/model/blog.js
+++ b/model/blog.js
@@ -119,6 +119,13 @@ class Blog {
           }
           self[key] = value;
         }
+        // If blog is reopened (status → edit or open), clear all exportedBy markers
+        if (data.status && (data.status === "edit" || data.status === "open") &&
+            previousBlogState.status !== data.status) {
+          if (self.exportedBy && typeof self.exportedBy === "object") {
+            self.exportedBy = {};
+          }
+        }
         cb();
       }
     ], function (err) {
@@ -304,6 +311,14 @@ class Blog {
             }
           }
           self["exported" + options.lang] = false;
+          // Clear exportedBy marker for this language across all export profiles
+          if (self.exportedBy && typeof self.exportedBy === "object") {
+            for (const profile of Object.keys(self.exportedBy)) {
+              if (self.exportedBy[profile] && typeof self.exportedBy[profile] === "object") {
+                delete self.exportedBy[profile][options.lang];
+              }
+            }
+          }
         }
         callback();
       }
@@ -845,6 +860,21 @@ class Blog {
     });
   }
 
+  // markAsExported(user, exportProfile, lang, callback)
+  // Sets the export marker for the given exportProfile and lang.
+  // Goes through setAndSave (not a direct save()) so a "exportedBy" change
+  // log entry is written, same as every other blog mutation.
+  markAsExported(user, exportProfile, lang, callback) {
+    debug("markAsExported");
+    const currentExportedBy = (this.exportedBy && typeof this.exportedBy === "object") ? this.exportedBy : {};
+    const updatedExportedBy = JSON.parse(JSON.stringify(currentExportedBy));
+    if (!updatedExportedBy[exportProfile] || typeof updatedExportedBy[exportProfile] !== "object") {
+      updatedExportedBy[exportProfile] = {};
+    }
+    updatedExportedBy[exportProfile][lang] = new Date().toISOString();
+    this.setAndSave(user, { exportedBy: updatedExportedBy }, callback);
+  }
+
   calculateTimeToClose(callback) {
     debug("Blog.prototype.calculateTimeToClose");
     if (this._timeToClose) return callback();
@@ -1203,6 +1233,126 @@ export function findCurrentEditBlog(callback) {
   });
 }
 
+// getOutstandingLangsForBlog(blog, exportProfile, langs)
+// Returns the subset of langs for which blog is closed but not yet exported
+// under exportProfile. Shared by findBlogsForOutstandingExport,
+// buildOutstandingExportZip and the dry-run listing in routes/api.js.
+function getOutstandingLangsForBlog(blog, exportProfile, langs) {
+  return langs.filter(function(lang) {
+    if (blog["close" + lang] !== true) return false;
+    const exportedBy = blog.exportedBy;
+    if (!exportedBy || !exportedBy[exportProfile]) return true;
+    return !exportedBy[exportProfile][lang];
+  });
+}
+
+// findBlogsForOutstandingExport(exportProfile, langs, callback)
+// Returns all WeeklyNote blogs that:
+//   - have status 'edit' or 'closed'
+//   - have close{LANG} === true for at least one of the given langs
+//   - have NOT yet been exported under exportProfile for that lang
+//     (i.e. exportedBy[exportProfile][lang] is not set)
+// langs: array of language codes, e.g. ["DE","EN"]
+export function findBlogsForOutstandingExport(exportProfile, langs, callback) {
+  function _findBlogsForOutstandingExport(callback) {
+    debug("findBlogsForOutstandingExport");
+    find(function(err, blogs) {
+      if (err) return callback(err);
+      if (!blogs || blogs.length === 0) return callback(null, []);
+
+      const eligible = blogs.filter(function(blog) {
+        if (!isWeeklyNoteBlog(blog)) return false;
+        if (blog.status !== "edit" && blog.status !== "closed") return false;
+        return getOutstandingLangsForBlog(blog, exportProfile, langs).length > 0;
+      });
+
+      return callback(null, eligible);
+    });
+  }
+
+  if (callback) {
+    return _findBlogsForOutstandingExport(callback);
+  }
+  return new Promise((resolve, reject) => {
+    _findBlogsForOutstandingExport((err, result) => err ? reject(err) : resolve(result));
+  });
+}
+
+// buildOutstandingExportZip(exportProfile, langs, callback)
+// Renders all eligible blogs (from findBlogsForOutstandingExport) into a single combined ZIP.
+// Returns { archive: ZipArchive|null, toMark: [{blog, lang}], failures: [{blog, lang, error}] }
+// archive is null when no eligible blogs exist.
+// A rendering failure for one blog/lang does NOT abort the whole batch: it is
+// recorded in `failures` and skipped, so the other blogs/langs still get exported.
+export function buildOutstandingExportZip(exportProfile, langs, callback) {
+  function _buildOutstandingExportZip(callback) {
+    debug("buildOutstandingExportZip");
+
+    const profileConfig = config.getValue("ExportProfiles", exportProfile);
+    if (!profileConfig) {
+      return callback(new Error(`Unknown export profile: ${exportProfile}`));
+    }
+    if (!profileConfig.pathTemplate) {
+      return callback(new Error(`Export profile '${exportProfile}' has no pathTemplate and cannot be used for outstanding bundle export`));
+    }
+
+    const rendererType = profileConfig.renderer || "HTML";
+    const rendererOptions = profileConfig.rendererOptions;
+    const pathTemplate = profileConfig.pathTemplate;
+
+    findBlogsForOutstandingExport(exportProfile, langs, function(err, blogs) {
+      if (err) return callback(err);
+      if (blogs.length === 0) return callback(null, { archive: null, toMark: [], failures: [] });
+
+      const archive = new ZipArchive("zip", { zlib: { level: 9 } });
+      const toMark = [];
+      const failures = [];
+
+      eachSeries(blogs, function(blog, blogCb) {
+        const eligibleLangs = getOutstandingLangsForBlog(blog, exportProfile, langs);
+
+        eachSeries(eligibleLangs, function(exportLang, langCb) {
+          blog.getPreviewData({ lang: exportLang, createTeam: true, disableNotranslation: true, warningOnEmptyMarkdown: true }, function(err, data) {
+            if (err) {
+              failures.push({ blog, lang: exportLang, error: err });
+              return langCb();
+            }
+
+            let content;
+            try {
+              const renderer = blogRenderer.createRenderer(rendererType, blog, rendererOptions);
+              content = renderer.renderBlog(exportLang, data, false);
+            } catch (renderErr) {
+              failures.push({ blog, lang: exportLang, error: renderErr });
+              return langCb();
+            }
+
+            const wn_4_digit = String(blog.name).replace(/\D/g, "").padStart(4, "0");
+            const exportPath = util.replaceTemplateVariables(pathTemplate,
+              { lang: language.wpExportName(exportLang).toLowerCase(), "blogNumber-4-digits": wn_4_digit });
+            const fileName = `${exportPath}.md`;
+
+            archive.append(content, { name: fileName });
+            toMark.push({ blog, lang: exportLang });
+            langCb();
+          });
+        }, blogCb);
+      }, function(err) {
+        if (err) return callback(err);
+        archive.finalize();
+        return callback(null, { archive, toMark, failures });
+      });
+    });
+  }
+
+  if (callback) {
+    return _buildOutstandingExportZip(callback);
+  }
+  return new Promise((resolve, reject) => {
+    _buildOutstandingExportZip((err, result) => err ? reject(err) : resolve(result));
+  });
+}
+
 // Create a blog in the database,
 // createNewBlog(proto,callback)
 // for parameter see create
@@ -1556,6 +1706,9 @@ const blogModule = {
   findBlogByRouteId: findBlogByRouteId,
   findBlogByRouteIdForUser: findBlogByRouteIdForUser,
   findCurrentEditBlog: findCurrentEditBlog,
+  findBlogsForOutstandingExport: findBlogsForOutstandingExport,
+  buildOutstandingExportZip: buildOutstandingExportZip,
+  getOutstandingLangsForBlog: getOutstandingLangsForBlog,
   getTBC: getTBC,
   create: create,
   sortArticles: sortArticles,

--- a/model/blog.js
+++ b/model/blog.js
@@ -862,8 +862,19 @@ class Blog {
 
   // markAsExported(user, exportProfile, lang, callback)
   // Sets the export marker for the given exportProfile and lang.
-  // Goes through setAndSave (not a direct save()) so a "exportedBy" change
-  // log entry is written, same as every other blog mutation.
+  // Goes through setAndSave, same as every other blog mutation - "every
+  // change is broadcast to every notification receiver, and it's up to
+  // each receiver to decide whether it's relevant" is exactly how
+  // MailReceiver/SlackReceiver already behave. The receivers that would
+  // otherwise turn this into editor-facing noise are taught to ignore it:
+  // LogModuleReceiver is wrapped in a FilterReceiver (see
+  // notification/messageCenter.js) so an exportedBy-only change never
+  // becomes a Postgres changes-log row, and Mail/Slack already only react
+  // to an actual `change.status`, which this never sets. The admin-facing
+  // audit trail instead goes to a rotating text log file, written by
+  // notification/exportReceiver.js listening on the same broadcast - same
+  // reasoning as the existing mail delivery log (maillog_*): less Postgres
+  // load, nothing editors need to see, admins can still read it.
   markAsExported(user, exportProfile, lang, callback) {
     debug("markAsExported");
     const currentExportedBy = (this.exportedBy && typeof this.exportedBy === "object") ? this.exportedBy : {};

--- a/model/blog.js
+++ b/model/blog.js
@@ -1257,14 +1257,34 @@ function getOutstandingLangsForBlog(blog, exportProfile, langs) {
   });
 }
 
-// findBlogsForOutstandingExport(exportProfile, langs, callback)
+// isWithinBlogNumberRange(blog, options)
+// options.minBlogNumber / options.maxBlogNumber are inclusive bounds on the
+// numeric WN number (e.g. 256 for "WN256"). Lets a caller page through a
+// large backlog of outstanding blogs instead of getting all of them (there
+// can be hundreds) in a single response.
+function isWithinBlogNumberRange(blog, options) {
+  if (!options) return true;
+  const number = getComparableBlogNumber(blog);
+  if (number === null) return false;
+  if (typeof options.minBlogNumber === "number" && number < options.minBlogNumber) return false;
+  if (typeof options.maxBlogNumber === "number" && number > options.maxBlogNumber) return false;
+  return true;
+}
+
+// findBlogsForOutstandingExport(exportProfile, langs, options, callback)
+// options is optional: { minBlogNumber, maxBlogNumber } (both inclusive).
 // Returns all WeeklyNote blogs that:
 //   - have status 'edit' or 'closed'
+//   - are within [minBlogNumber, maxBlogNumber] if given
 //   - have close{LANG} === true for at least one of the given langs
 //   - have NOT yet been exported under exportProfile for that lang
 //     (i.e. exportedBy[exportProfile][lang] is not set)
 // langs: array of language codes, e.g. ["DE","EN"]
-export function findBlogsForOutstandingExport(exportProfile, langs, callback) {
+export function findBlogsForOutstandingExport(exportProfile, langs, options, callback) {
+  if (typeof options === "function") {
+    callback = options;
+    options = null;
+  }
   function _findBlogsForOutstandingExport(callback) {
     debug("findBlogsForOutstandingExport");
     find(function(err, blogs) {
@@ -1274,6 +1294,7 @@ export function findBlogsForOutstandingExport(exportProfile, langs, callback) {
       const eligible = blogs.filter(function(blog) {
         if (!isWeeklyNoteBlog(blog)) return false;
         if (blog.status !== "edit" && blog.status !== "closed") return false;
+        if (!isWithinBlogNumberRange(blog, options)) return false;
         return getOutstandingLangsForBlog(blog, exportProfile, langs).length > 0;
       });
 
@@ -1289,13 +1310,19 @@ export function findBlogsForOutstandingExport(exportProfile, langs, callback) {
   });
 }
 
-// buildOutstandingExportZip(exportProfile, langs, callback)
+// buildOutstandingExportZip(exportProfile, langs, options, callback)
+// options is optional: { minBlogNumber, maxBlogNumber }, see
+// findBlogsForOutstandingExport.
 // Renders all eligible blogs (from findBlogsForOutstandingExport) into a single combined ZIP.
 // Returns { archive: ZipArchive|null, toMark: [{blog, lang}], failures: [{blog, lang, error}] }
 // archive is null when no eligible blogs exist.
 // A rendering failure for one blog/lang does NOT abort the whole batch: it is
 // recorded in `failures` and skipped, so the other blogs/langs still get exported.
-export function buildOutstandingExportZip(exportProfile, langs, callback) {
+export function buildOutstandingExportZip(exportProfile, langs, options, callback) {
+  if (typeof options === "function") {
+    callback = options;
+    options = null;
+  }
   function _buildOutstandingExportZip(callback) {
     debug("buildOutstandingExportZip");
 
@@ -1311,7 +1338,7 @@ export function buildOutstandingExportZip(exportProfile, langs, callback) {
     const rendererOptions = profileConfig.rendererOptions;
     const pathTemplate = profileConfig.pathTemplate;
 
-    findBlogsForOutstandingExport(exportProfile, langs, function(err, blogs) {
+    findBlogsForOutstandingExport(exportProfile, langs, options, function(err, blogs) {
       if (err) return callback(err);
       if (blogs.length === 0) return callback(null, { archive: null, toMark: [], failures: [] });
 

--- a/notification/FilterReceiver.js
+++ b/notification/FilterReceiver.js
@@ -1,0 +1,51 @@
+// Generic receiver wrapper: forwards a messageCenter event to the wrapped
+// receiver only if the given predicate (keyed by method name) returns true
+// for that event's arguments; otherwise it just calls back without
+// touching the wrapped receiver at all.
+//
+// This formalizes, as a reusable building block, the same idea
+// UserConfigFilter already applies ad-hoc for per-user mail preferences:
+// "every setAndSave change is broadcast to every receiver, and it's up to
+// each receiver (or a filter sitting in front of it) to decide whether
+// it's actually relevant." Use it to keep a receiver from reacting to
+// changes it was never meant to see - e.g. wrapping LogModuleReceiver so
+// purely operational fields (like the `exportedBy` export marker, see
+// notification/exportReceiver.js) don't turn into a Postgres changes-log
+// row that editors see in the blog history tab.
+//
+// filters: { [methodName]: (...eventArgs) => boolean }
+// Any method without an entry in `filters` is passed through unfiltered.
+
+import _debug from "debug";
+
+const debug = _debug("OSMBC:notification:FilterReceiver");
+
+const RECEIVER_METHODS = [
+  "sendInfo",
+  "updateArticle",
+  "updateBlog",
+  "sendReviewStatus",
+  "sendCloseStatus",
+  "addComment",
+  "editComment"
+];
+
+class FilterReceiver {
+  constructor(receiver, filters) {
+    this.receiver = receiver;
+    this.filters = filters || {};
+  }
+}
+
+for (const method of RECEIVER_METHODS) {
+  FilterReceiver.prototype[method] = function (...args) {
+    debug("FilterReceiver::%s", method);
+    const callback = args[args.length - 1];
+    const eventArgs = args.slice(0, -1);
+    const filter = this.filters[method];
+    if (filter && !filter(...eventArgs)) return callback();
+    return this.receiver[method](...args);
+  };
+}
+
+export default FilterReceiver;

--- a/notification/exportLogWriter.js
+++ b/notification/exportLogWriter.js
@@ -1,0 +1,63 @@
+// Plain rotating-text-file audit trail for bulk-export marker writes
+// (see CLAUDE.local.md, section "outstanding export").
+//
+// Deliberately NOT a messageCenter receiver and NOT going through
+// setAndSave: marking a blog as exported is an operational record for
+// admins, not editorial content. Routing it through setAndSave would
+// (a) create a Postgres changes-log row visible to editors in the blog
+// history tab, and (b) trigger the mail/Slack "blog changed" notification
+// fan-out that messageCenter.global.updateBlog broadcasts on every field
+// change - editors would get spurious "WN1234 changed status to ..."
+// notifications every time an export pipeline pulls the outstanding ZIP.
+//
+// Mirrors the existing maillog_* convention (notification/mailReceiver.js):
+// same winston + daily-rotate-file approach, less load on Postgres, admins
+// can still read the file. Config keys are optional (default instead of
+// mustExist) so existing environments don't need a config change to keep
+// starting up.
+
+import { join } from "path";
+import { existsSync } from "fs";
+import winston from "winston";
+import "winston-daily-rotate-file";
+import config from "../config.js";
+import _debug from "debug";
+
+const debug = _debug("OSMBC:notification:exportLogWriter");
+
+let logDir = config.getValue("exportlog_directory", { default: "." });
+const logNamePrefix = config.getValue("exportlog_prefix", { default: "exportlog%DATE%.log" });
+const logNameDateFormat = config.getValue("exportlog_dateformat", { default: "YYYY-MM-DD" });
+if (logDir === ".") logDir = join(config.getDirName(), "..");
+
+if (!(existsSync(logDir))) {
+  console.error("Missing Directory (exportlog_directory) %s", logDir);
+  process.exit(1);
+}
+
+const transport = new winston.transports.DailyRotateFile({
+  filename: logNamePrefix,
+  dirname: logDir,
+  datePattern: logNameDateFormat,
+  level: "info"
+});
+
+const logger = winston.createLogger({
+  transports: [transport]
+});
+
+// logMarkAsExported({user, blog, exportProfile, lang})
+// user: OSMUser string (real user, or the synthetic "apikey:<label>"
+//       identity used for shared API keys - see routes/api.js)
+function logMarkAsExported({ user, blog, exportProfile, lang }) {
+  debug("logMarkAsExported");
+  logger.info({ user, blog, exportProfile, lang, timestamp: new Date().toISOString() });
+}
+
+const exportLogWriter = { logMarkAsExported };
+export default exportLogWriter;
+
+// Exposes the underlying winston logger so tests can stub logger.info(...)
+// instead of asserting on the actual log file, same pattern as
+// MailReceiverForTestOnly in notification/mailReceiver.js.
+export const ExportLogWriterForTestOnly = { logger };

--- a/notification/exportReceiver.js
+++ b/notification/exportReceiver.js
@@ -1,0 +1,45 @@
+// Listens on the same messageCenter `updateBlog` broadcast every
+// setAndSave() call produces (same mechanism MailReceiver/SlackReceiver
+// use), and reacts only when a change actually touches `exportedBy` - see
+// Blog.prototype.markAsExported in model/blog.js. Relevant lang(s) get
+// written to the export text log (notification/exportLogWriter.js).
+//
+// Deliberately NOT wired through the blog's normal Postgres changes-log:
+// marking a blog as exported is an operational record for admins, not
+// editorial content. LogModuleReceiver is wrapped in a FilterReceiver
+// instead (see notification/messageCenter.js) so this doesn't ALSO end up
+// in the changes-log editors see in the blog history tab, and doesn't
+// trigger the mail/Slack "blog changed" notifications either (those two
+// receivers already decide based on `change.status`, which a
+// markAsExported call never sets).
+
+import exportLogWriter from "./exportLogWriter.js";
+import _debug from "debug";
+
+const debug = _debug("OSMBC:notification:exportReceiver");
+
+class ExportReceiver {
+  sendInfo(object, cb) { return cb(); }
+  updateArticle(user, article, change, cb) { return cb(); }
+  sendReviewStatus(user, blog, lang, status, cb) { return cb(); }
+  sendCloseStatus(user, blog, lang, status, cb) { return cb(); }
+  addComment(user, article, text, cb) { return cb(); }
+  editComment(user, article, index, text, cb) { return cb(); }
+
+  updateBlog(user, blog, change, cb) {
+    debug("ExportReceiver::updateBlog");
+    if (!change.exportedBy || typeof change.exportedBy !== "object") return cb();
+
+    for (const exportProfile in change.exportedBy) {
+      const newMarkers = change.exportedBy[exportProfile] || {};
+      const previousMarkers = (blog.exportedBy && blog.exportedBy[exportProfile]) || {};
+      for (const lang in newMarkers) {
+        if (newMarkers[lang] === previousMarkers[lang]) continue;
+        exportLogWriter.logMarkAsExported({ user: user.OSMUser, blog: blog.name, exportProfile, lang });
+      }
+    }
+    return cb();
+  }
+}
+
+export default ExportReceiver;

--- a/notification/messageCenter.js
+++ b/notification/messageCenter.js
@@ -1,9 +1,24 @@
 import _debug from "debug";
 import async from "async";
 import LogModuleReceiver from "../notification/LogModuleReceiver.js";
+import FilterReceiver from "../notification/FilterReceiver.js";
+import ExportReceiver from "../notification/exportReceiver.js";
 
 import config from "../config.js";
 const debug = _debug("OSMBC:notification:messageCenter");
+
+// Blog fields that are purely operational (not editorial content) and
+// therefore must not turn a setAndSave() call into a Postgres changes-log
+// row that editors see in the blog history tab. See
+// Blog.prototype.markAsExported in model/blog.js and
+// notification/exportReceiver.js.
+const OPERATIONAL_ONLY_BLOG_FIELDS = ["exportedBy"];
+
+function isEditorialBlogChange(user, blog, change) {
+  const keys = Object.keys(change).filter((k) => typeof change[k] !== "undefined");
+  if (keys.length === 0) return false;
+  return keys.some((k) => !OPERATIONAL_ONLY_BLOG_FIELDS.includes(k));
+}
 
 
 
@@ -90,7 +105,10 @@ function initialise(callback) {
 
 
 
-  messageCenter.global.registerReceiver(new LogModuleReceiver());
+  messageCenter.global.registerReceiver(
+    new FilterReceiver(new LogModuleReceiver(), { updateBlog: isEditorialBlogChange })
+  );
+  messageCenter.global.registerReceiver(new ExportReceiver());
 
   config.logger.info("Message Center initialised.");
   if (callback) return callback();

--- a/notification/slackReceiver.js
+++ b/notification/slackReceiver.js
@@ -200,15 +200,19 @@ export class SlackReceiver {
   updateBlog(user, blog, change, callback) {
     debug("SlackReceiver::updateBlog %s", this.name);
 
-
-
+    const isCreate = !blog.name && change.name;
+    const isStatusChange = typeof change.status !== "undefined" && blog.status !== change.status;
+    // Anything else (e.g. only the operational `exportedBy` export marker
+    // changed, see model/blog.js markAsExported) is not worth a message -
+    // without this check every setAndSave() call, regardless of which
+    // field it touched, used to post "changed status to undefined".
+    if (!isCreate && !isStatusChange) return callback();
 
     let subject = blogNameSlack(blog.name, change.name);
 
-
-    if (!blog.name && change.name) {
+    if (isCreate) {
       subject += " was created\n";
-    } else if (blog.status !== change.status) {
+    } else {
       subject += " changed status to " + change.status + "\n";
     }
     const username = botName + "(" + user.OSMUser + ")";

--- a/routes/api.js
+++ b/routes/api.js
@@ -10,6 +10,7 @@ import articleModule from "../model/article.js";
 import config from "../config.js";
 import language from "../model/language.js";
 import blogModule from "../model/blog.js";
+import { ZipArchive } from "archiver";
 
 const debug = _debug("OSMBC:routes:api");
 const publicApiRouter  = express.Router();
@@ -216,6 +217,175 @@ function checkBlogId(req, res, next, id) {
   });
 }
 
+// Exclusive-per-profile guard so two concurrent outstanding-export requests
+// for the SAME exportProfile cannot pick up and re-deliver the same blogs
+// before either has had a chance to mark them as exported.
+// NOTE: this is an in-process guard only (a Set kept in memory). It does not
+// protect a multi-instance/cluster deployment - that would need a Postgres
+// advisory lock or similar. Requests for different exportProfiles, or plain
+// dry-run requests, are never blocked by it.
+const outstandingExportLocks = new Set();
+
+// Resolves the identity to attribute the exportedBy change-log entry to.
+// checkApiKey sets req.user for a per-user apiKey, or req.apiKey to the
+// label configured under `apiKeys` for a shared key.
+function getOutstandingExportUser(req) {
+  if (req.user && req.user.OSMUser) return { OSMUser: req.user.OSMUser };
+  return { OSMUser: "apikey:" + (req.apiKey || "unknown") };
+}
+
+/**
+ * Download a combined ZIP of all blogs with outstanding (not yet delivered) export,
+ * or (with `dryRun=true`) just list what that download would currently contain.
+ *
+ * Route params:
+ * - apiKey {string} API key used by middleware `checkApiKey`
+ *
+ * Query params:
+ * - exportProfile {string} required profile name from config key `ExportProfiles`
+ * - lang {string} optional language code or `ALL` (defaults to all configured languages)
+ * - dryRun {string} optional, "true" returns a JSON preview instead of building/marking anything
+ *
+ * Behavior:
+ * - Finds all WeeklyNote blogs that are closed for the requested lang(s) and not yet exported
+ * - Returns a combined ZIP with one file per blog+lang
+ * - A rendering failure for one blog/lang is skipped and reported via the
+ *   `X-Outstanding-Export-Warnings` response header, it does not abort the whole batch
+ * - Sets exportedBy markers (with a change-log entry) after the response is fully sent
+ * - If no eligible blogs: respects `noContentBehavior` in the ExportProfile config
+ *   ("404" = default, "emptyZip" = return empty ZIP with HTTP 200)
+ * - Rejects with 409 if another outstanding export for the same exportProfile is in flight
+ */
+function getBlogPreviewDownloadOutstanding(req, res, next) {
+  debug("getBlogPreviewDownloadOutstanding");
+
+  const exportProfile = (typeof req.query.exportProfile === "string") ? req.query.exportProfile.trim() : "";
+  if (!exportProfile) {
+    const error = new Error("Missing exportProfile");
+    error.status = 422;
+    error.type = "API";
+    return next(error);
+  }
+
+  const profileConfig = config.getValue("ExportProfiles", exportProfile);
+  if (!profileConfig) {
+    const error = new Error("Unknown export profile: " + exportProfile);
+    error.status = 422;
+    error.type = "API";
+    return next(error);
+  }
+
+  if (!profileConfig.pathTemplate) {
+    const error = new Error(`Export profile '${exportProfile}' has no pathTemplate and cannot be used for outstanding bundle export`);
+    error.status = 422;
+    error.type = "API";
+    return next(error);
+  }
+
+  let langs = req.query.lang;
+  if (!langs || langs === "ALL") {
+    langs = language.getLid();
+  } else if (typeof langs === "string") {
+    langs = [langs];
+  } else if (!Array.isArray(langs)) {
+    langs = language.getLid();
+  }
+
+  const dryRun = req.query.dryRun === "true";
+
+  if (dryRun) {
+    return blogModule.findBlogsForOutstandingExport(exportProfile, langs, function(err, blogs) {
+      if (err) return next(err);
+      const preview = blogs.map(function(blog) {
+        return { name: blog.name, langs: blogModule.getOutstandingLangsForBlog(blog, exportProfile, langs) };
+      });
+      res.set("content-type", "application/json");
+      res.end(JSON.stringify({ exportProfile: exportProfile, count: preview.length, blogs: preview }));
+    });
+  }
+
+  if (outstandingExportLocks.has(exportProfile)) {
+    const conflict = new Error(`Outstanding export for profile '${exportProfile}' is already in progress, please retry shortly`);
+    conflict.status = 409;
+    conflict.type = "API";
+    return next(conflict);
+  }
+  outstandingExportLocks.add(exportProfile);
+  let markingStarted = false;
+  function releaseLock() { outstandingExportLocks.delete(exportProfile); }
+
+  blogModule.buildOutstandingExportZip(exportProfile, langs, function(err, result) {
+    if (err) {
+      releaseLock();
+      return next(err);
+    }
+
+    const { archive, toMark, failures } = result;
+
+    if (failures && failures.length > 0) {
+      const failureList = failures.map((f) => `${f.blog.name}:${f.lang}`).join(",");
+      debug("Skipped %d blog/lang exports due to render errors: %s", failures.length, failureList);
+      res.set("X-Outstanding-Export-Warnings", failureList);
+    }
+
+    if (!archive) {
+      releaseLock();
+      const noContentBehavior = profileConfig.noContentBehavior || "404";
+      if (noContentBehavior === "emptyZip") {
+        const emptyArchive = new ZipArchive("zip", { zlib: { level: 9 } });
+        res.set("content-type", "application/zip");
+        res.attachment("outstanding.zip");
+        emptyArchive.pipe(res);
+        emptyArchive.finalize();
+        return;
+      }
+      const notFound = new Error("No blogs available for outstanding export");
+      notFound.status = 404;
+      notFound.type = "API";
+      return next(notFound);
+    }
+
+    let zipFileName = "outstanding.zip";
+    if (profileConfig.fileNameTemplate) {
+      const templated = profileConfig.fileNameTemplate.replace(/##[^#]+##/g, "outstanding");
+      if (templated && templated.trim()) {
+        zipFileName = templated.toLowerCase().endsWith(".zip") ? templated : `${templated}.zip`;
+      }
+    }
+
+    res.set("content-type", "application/zip");
+    res.attachment(zipFileName);
+
+    const user = getOutstandingExportUser(req);
+
+    res.on("finish", function() {
+      markingStarted = true;
+      const markingFailures = [];
+      async.eachSeries(toMark, function(item, cb) {
+        item.blog.markAsExported(user, exportProfile, item.lang, function(err) {
+          // A single blog's marker failing to save must not stop the rest
+          // from being marked - the content for ALL of them was already
+          // delivered in the response that just finished.
+          if (err) markingFailures.push({ blog: item.blog.name, lang: item.lang, error: err.message });
+          cb();
+        });
+      }, function() {
+        if (markingFailures.length > 0) {
+          debug("Some exportedBy markers could not be set (blog stays 'outstanding' and will be re-offered next time): %j", markingFailures);
+        }
+        releaseLock();
+      });
+    });
+    // Safety net: if the client disconnects before "finish" fires, marking
+    // never starts, so release the lock here instead of leaving it stuck.
+    res.on("close", function() {
+      if (!markingStarted) releaseLock();
+    });
+
+    archive.pipe(res);
+  });
+}
+
 /**
  * Download a rendered blog preview using a configured export profile.
  *
@@ -267,6 +437,7 @@ publicApiRouter.get("/monitorPostgres/:apiKey", isPostgresUp);
 
 publicApiRouter.post("/collectArticle/:apiKey", collectArticle);
 publicApiRouter.get("/collect/:apiKey", collectArticleLink);
+publicApiRouter.get("/blogPreviewDownload/:apiKey/outstanding", getBlogPreviewDownloadOutstanding);
 publicApiRouter.get("/blogPreviewDownload/:apiKey/:blog_id", getBlogPreviewDownload);
 
 export default publicApiRouter;

--- a/routes/api.js
+++ b/routes/api.js
@@ -234,6 +234,22 @@ function getOutstandingExportUser(req) {
   return { OSMUser: "apikey:" + (req.apiKey || "unknown") };
 }
 
+// Parses an optional minBlogNumber/maxBlogNumber query param into a
+// non-negative integer. Returns { value: undefined } when the param wasn't
+// given at all, or { error } (a ready-to-use API error) when it was given
+// but isn't a valid non-negative integer.
+function parseBlogNumberBound(raw, fieldName) {
+  if (typeof raw === "undefined") return { value: undefined };
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    const error = new Error(`Invalid ${fieldName}: must be a non-negative integer`);
+    error.status = 422;
+    error.type = "API";
+    return { error };
+  }
+  return { value: parsed };
+}
+
 /**
  * Download a combined ZIP of all blogs with outstanding (not yet delivered) export,
  * or (with `dryRun=true`) just list what that download would currently contain.
@@ -244,10 +260,13 @@ function getOutstandingExportUser(req) {
  * Query params:
  * - exportProfile {string} required profile name from config key `ExportProfiles`
  * - lang {string} optional language code or `ALL` (defaults to all configured languages)
+ * - minBlogNumber {number} optional, inclusive lower bound on the WN number (e.g. 256 for "WN256")
+ * - maxBlogNumber {number} optional, inclusive upper bound on the WN number
  * - dryRun {string} optional, "true" returns a JSON preview instead of building/marking anything
  *
  * Behavior:
- * - Finds all WeeklyNote blogs that are closed for the requested lang(s) and not yet exported
+ * - Finds all WeeklyNote blogs that are closed for the requested lang(s) and not yet exported,
+ *   optionally narrowed to [minBlogNumber, maxBlogNumber] to page through a large backlog
  * - Returns a combined ZIP with one file per blog+lang
  * - A rendering failure for one blog/lang is skipped and reported via the
  *   `X-Outstanding-Export-Warnings` response header, it does not abort the whole batch
@@ -291,16 +310,39 @@ function getBlogPreviewDownloadOutstanding(req, res, next) {
     langs = language.getLid();
   }
 
+  // Optional WN-number range, so a consumer can page through a large
+  // backlog (e.g. an initial catch-up run) instead of getting everything
+  // outstanding in one response.
+  const minBound = parseBlogNumberBound(req.query.minBlogNumber, "minBlogNumber");
+  if (minBound.error) return next(minBound.error);
+  const maxBound = parseBlogNumberBound(req.query.maxBlogNumber, "maxBlogNumber");
+  if (maxBound.error) return next(maxBound.error);
+  if (typeof minBound.value === "number" && typeof maxBound.value === "number" && minBound.value > maxBound.value) {
+    const error = new Error("minBlogNumber must not be greater than maxBlogNumber");
+    error.status = 422;
+    error.type = "API";
+    return next(error);
+  }
+  const blogNumberOptions = {};
+  if (typeof minBound.value === "number") blogNumberOptions.minBlogNumber = minBound.value;
+  if (typeof maxBound.value === "number") blogNumberOptions.maxBlogNumber = maxBound.value;
+
   const dryRun = req.query.dryRun === "true";
 
   if (dryRun) {
-    return blogModule.findBlogsForOutstandingExport(exportProfile, langs, function(err, blogs) {
+    return blogModule.findBlogsForOutstandingExport(exportProfile, langs, blogNumberOptions, function(err, blogs) {
       if (err) return next(err);
       const preview = blogs.map(function(blog) {
         return { name: blog.name, langs: blogModule.getOutstandingLangsForBlog(blog, exportProfile, langs) };
       });
       res.set("content-type", "application/json");
-      res.end(JSON.stringify({ exportProfile: exportProfile, count: preview.length, blogs: preview }));
+      res.end(JSON.stringify({
+        exportProfile: exportProfile,
+        minBlogNumber: blogNumberOptions.minBlogNumber ?? null,
+        maxBlogNumber: blogNumberOptions.maxBlogNumber ?? null,
+        count: preview.length,
+        blogs: preview
+      }));
     });
   }
 
@@ -314,7 +356,7 @@ function getBlogPreviewDownloadOutstanding(req, res, next) {
   let markingStarted = false;
   function releaseLock() { outstandingExportLocks.delete(exportProfile); }
 
-  blogModule.buildOutstandingExportZip(exportProfile, langs, function(err, result) {
+  blogModule.buildOutstandingExportZip(exportProfile, langs, blogNumberOptions, function(err, result) {
     if (err) {
       releaseLock();
       return next(err);

--- a/test/model.blog.test.js
+++ b/test/model.blog.test.js
@@ -3,6 +3,7 @@
 import async from "async";
 import should from "should";
 import nock from "nock";
+import sinon from "sinon";
 
 import testutil from "./testutil.js";
 
@@ -10,6 +11,7 @@ import config from "../config.js";
 import logModule from "../model/logModule.js";
 import blogModule from "../model/blog.js";
 import articleModule from "../model/article.js";
+import blogRenderer from "../render/BlogRenderer.js";
 
 function toDateKey(value) {
   const d = new Date(value);
@@ -807,6 +809,203 @@ describe("model/blog", function() {
       should(blogModule.sanitizeBlogKey("WN34887")).eql("WN34887");
       should(blogModule.sanitizeBlogKey("blog34887")).eql("34887");
       should(blogModule.sanitizeBlogKey("blog348\n87")).eql("34887");
+    });
+  });
+
+  describe("findBlogsForOutstandingExport", function() {
+    beforeEach(function(bddone) {
+      testutil.clearDB(bddone);
+    });
+
+    it("should return an empty array when there are no blogs at all", function(bddone) {
+      blogModule.findBlogsForOutstandingExport("HugoDownload", ["DE", "EN"], function(err, result) {
+        should.not.exist(err);
+        should(result).eql([]);
+        bddone();
+      });
+    });
+
+    it("should return a blog that is closed for the language and not yet exported", function(bddone) {
+      blogModule.createNewBlog({ OSMUser: "test" }, { name: "WN2000", status: "edit", closeDE: true }, function(err) {
+        should.not.exist(err);
+        blogModule.findBlogsForOutstandingExport("HugoDownload", ["DE", "EN"], function(err, result) {
+          should.not.exist(err);
+          should(result.length).equal(1);
+          should(result[0].name).equal("WN2000");
+          bddone();
+        });
+      });
+    });
+
+    it("should not return a blog already exported under this profile+lang", function(bddone) {
+      blogModule.createNewBlog({ OSMUser: "test" }, {
+        name: "WN2001",
+        status: "closed",
+        closeDE: true,
+        exportedBy: { HugoDownload: { DE: "2020-01-01T00:00:00.000Z" } }
+      }, function(err) {
+        should.not.exist(err);
+        blogModule.findBlogsForOutstandingExport("HugoDownload", ["DE"], function(err, result) {
+          should.not.exist(err);
+          should(result).eql([]);
+          bddone();
+        });
+      });
+    });
+
+    it("should not return a blog with status open, even if closed for the language", function(bddone) {
+      blogModule.createNewBlog({ OSMUser: "test" }, { name: "WN2002", status: "open", closeDE: true }, function(err) {
+        should.not.exist(err);
+        blogModule.findBlogsForOutstandingExport("HugoDownload", ["DE"], function(err, result) {
+          should.not.exist(err);
+          should(result).eql([]);
+          bddone();
+        });
+      });
+    });
+
+    it("should return only the not-yet-exported blogs among several candidates", function(bddone) {
+      async.series([
+        function(cb) { blogModule.createNewBlog({ OSMUser: "test" }, { name: "WN2003", status: "edit", closeDE: true }, cb); },
+        function(cb) {
+          blogModule.createNewBlog({ OSMUser: "test" }, {
+            name: "WN2004",
+            status: "closed",
+            closeDE: true,
+            exportedBy: { HugoDownload: { DE: "2020-01-01T00:00:00.000Z" } }
+          }, cb);
+        },
+        function(cb) { blogModule.createNewBlog({ OSMUser: "test" }, { name: "WN2005", status: "open", closeDE: true }, cb); }
+      ], function(err) {
+        should.not.exist(err);
+        blogModule.findBlogsForOutstandingExport("HugoDownload", ["DE"], function(err, result) {
+          should.not.exist(err);
+          should(result.length).equal(1);
+          should(result[0].name).equal("WN2003");
+          bddone();
+        });
+      });
+    });
+  });
+
+  describe("buildOutstandingExportZip", function() {
+    afterEach(function() {
+      sinon.restore();
+    });
+
+    beforeEach(function(bddone) {
+      testutil.importData({
+        clear: true,
+        blog: [
+          { name: "WN2200", status: "edit", categories: [{ EN: "Mapping", DE: "Mapping" }], closeDE: true },
+          { name: "WN2201", status: "edit", categories: [{ EN: "Mapping", DE: "Mapping" }], closeDE: true }
+        ],
+        article: [
+          { blog: "WN2200", title: "Article one", markdownDE: "* Article one DE", category: "Mapping" },
+          { blog: "WN2201", title: "Article two", markdownDE: "* Article two DE", category: "Mapping" }
+        ]
+      }, bddone);
+    });
+
+    it("should reject a profile without pathTemplate", function(bddone) {
+      blogModule.buildOutstandingExportZip("OsmbcDownload", ["DE"], function(err) {
+        should.exist(err);
+        should(err.message).containEql("pathTemplate");
+        bddone();
+      });
+    });
+
+    it("should skip a blog that fails to render but still export the others", function(bddone) {
+      const originalCreateRenderer = blogRenderer.createRenderer;
+      sinon.stub(blogRenderer, "createRenderer").callsFake(function(type, blog, options) {
+        if (blog.name === "WN2200") throw new Error("Simulated render failure");
+        return originalCreateRenderer(type, blog, options);
+      });
+
+      blogModule.buildOutstandingExportZip("HugoDownload", ["DE"], function(err, result) {
+        should.not.exist(err);
+        should.exist(result.archive);
+        should(result.failures.length).equal(1);
+        should(result.failures[0].blog.name).equal("WN2200");
+        should(result.failures[0].lang).equal("DE");
+        should(result.toMark.length).equal(1);
+        should(result.toMark[0].blog.name).equal("WN2201");
+        bddone();
+      });
+    });
+  });
+
+  describe("markAsExported", function() {
+    beforeEach(function(bddone) {
+      testutil.clearDB(bddone);
+    });
+
+    it("should set the marker and write a change-log entry attributing the given user", function(bddone) {
+      blogModule.createNewBlog({ OSMUser: "test" }, { name: "WN2300", status: "closed", closeDE: true }, function(err, blog) {
+        should.not.exist(err);
+        blog.markAsExported({ OSMUser: "apikey:hugoPipeline" }, "HugoDownload", "DE", function(err) {
+          should.not.exist(err);
+          testutil.getJsonWithId("blog", blog.id, function(err, result) {
+            should.not.exist(err);
+            should.exist(result.exportedBy.HugoDownload.DE);
+            logModule.find({ oid: blog.id, property: "exportedBy" }, function(err, result) {
+              should.not.exist(err);
+              should(result.length).equal(1);
+              should(result[0].user).equal("apikey:hugoPipeline");
+              bddone();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe("exportedBy marker reset", function() {
+    beforeEach(function(bddone) {
+      testutil.clearDB(bddone);
+    });
+
+    it("should clear the exportedBy marker for a language when it is reopened via closeBlog", function(bddone) {
+      blogModule.createNewBlog({ OSMUser: "test" }, {
+        name: "WN2100",
+        status: "edit",
+        closeDE: true,
+        closeEN: true,
+        exportedBy: {
+          HugoDownload: { DE: "2020-01-01T00:00:00.000Z", EN: "2020-01-01T00:00:00.000Z" }
+        }
+      }, function(err, blog) {
+        should.not.exist(err);
+        blog.closeBlog({ lang: "DE", user: { OSMUser: "user" }, status: false }, function(err) {
+          should.not.exist(err);
+          testutil.getJsonWithId("blog", blog.id, function(err, result) {
+            should.not.exist(err);
+            should(result.exportedBy.HugoDownload).not.have.property("DE");
+            should(result.exportedBy.HugoDownload.EN).equal("2020-01-01T00:00:00.000Z");
+            bddone();
+          });
+        });
+      });
+    });
+
+    it("should clear all exportedBy markers when the blog status changes to edit", function(bddone) {
+      blogModule.createNewBlog({ OSMUser: "test" }, {
+        name: "WN2101",
+        status: "closed",
+        exportedBy: {
+          HugoDownload: { DE: "2020-01-01T00:00:00.000Z", EN: "2020-01-01T00:00:00.000Z" }
+        }
+      }, function(err, blog) {
+        should.not.exist(err);
+        blog.setAndSave({ OSMUser: "user" }, { status: "edit" }, function(err) {
+          should.not.exist(err);
+          testutil.getJsonWithId("blog", blog.id, function(err, result) {
+            should.not.exist(err);
+            should(result.exportedBy).eql({});
+            bddone();
+          });
+        });
+      });
     });
   });
 });

--- a/test/model.blog.test.js
+++ b/test/model.blog.test.js
@@ -12,6 +12,7 @@ import logModule from "../model/logModule.js";
 import blogModule from "../model/blog.js";
 import articleModule from "../model/article.js";
 import blogRenderer from "../render/BlogRenderer.js";
+import { ExportLogWriterForTestOnly } from "../notification/exportLogWriter.js";
 
 function toDateKey(value) {
   const d = new Date(value);
@@ -936,11 +937,15 @@ describe("model/blog", function() {
   });
 
   describe("markAsExported", function() {
+    afterEach(function() {
+      sinon.restore();
+    });
+
     beforeEach(function(bddone) {
       testutil.clearDB(bddone);
     });
 
-    it("should set the marker and write a change-log entry attributing the given user", function(bddone) {
+    it("should set the marker without creating a Postgres changes-log entry", function(bddone) {
       blogModule.createNewBlog({ OSMUser: "test" }, { name: "WN2300", status: "closed", closeDE: true }, function(err, blog) {
         should.not.exist(err);
         blog.markAsExported({ OSMUser: "apikey:hugoPipeline" }, "HugoDownload", "DE", function(err) {
@@ -948,13 +953,33 @@ describe("model/blog", function() {
           testutil.getJsonWithId("blog", blog.id, function(err, result) {
             should.not.exist(err);
             should.exist(result.exportedBy.HugoDownload.DE);
+            // Goes through setAndSave like every mutation, but
+            // LogModuleReceiver is wrapped in a FilterReceiver (see
+            // notification/messageCenter.js) that skips exportedBy-only
+            // changes, so editors never see this in the blog history tab.
             logModule.find({ oid: blog.id, property: "exportedBy" }, function(err, result) {
               should.not.exist(err);
-              should(result.length).equal(1);
-              should(result[0].user).equal("apikey:hugoPipeline");
+              should(result.length).equal(0);
               bddone();
             });
           });
+        });
+      });
+    });
+
+    it("should write an entry to the text export log, attributing the given user", function(bddone) {
+      const infoStub = sinon.stub(ExportLogWriterForTestOnly.logger, "info");
+      blogModule.createNewBlog({ OSMUser: "test" }, { name: "WN2301", status: "closed", closeDE: true }, function(err, blog) {
+        should.not.exist(err);
+        blog.markAsExported({ OSMUser: "apikey:hugoPipeline" }, "HugoDownload", "DE", function(err) {
+          should.not.exist(err);
+          should(infoStub.calledOnce).be.True();
+          const logEntry = infoStub.getCall(0).args[0];
+          should(logEntry.user).equal("apikey:hugoPipeline");
+          should(logEntry.blog).equal("WN2301");
+          should(logEntry.exportProfile).equal("HugoDownload");
+          should(logEntry.lang).equal("DE");
+          bddone();
         });
       });
     });

--- a/test/model.blog.test.js
+++ b/test/model.blog.test.js
@@ -887,6 +887,51 @@ describe("model/blog", function() {
         });
       });
     });
+
+    describe("minBlogNumber / maxBlogNumber", function() {
+      beforeEach(function(bddone) {
+        async.series([
+          function(cb) { blogModule.createNewBlog({ OSMUser: "test" }, { name: "WN2010", status: "edit", closeDE: true }, cb); },
+          function(cb) { blogModule.createNewBlog({ OSMUser: "test" }, { name: "WN2020", status: "edit", closeDE: true }, cb); },
+          function(cb) { blogModule.createNewBlog({ OSMUser: "test" }, { name: "WN2030", status: "edit", closeDE: true }, cb); }
+        ], bddone);
+      });
+
+      it("should only return blogs within [minBlogNumber, maxBlogNumber]", function(bddone) {
+        blogModule.findBlogsForOutstandingExport("HugoDownload", ["DE"], { minBlogNumber: 2015, maxBlogNumber: 2025 }, function(err, result) {
+          should.not.exist(err);
+          should(result.length).equal(1);
+          should(result[0].name).equal("WN2020");
+          bddone();
+        });
+      });
+
+      it("should only apply minBlogNumber when maxBlogNumber is omitted", function(bddone) {
+        blogModule.findBlogsForOutstandingExport("HugoDownload", ["DE"], { minBlogNumber: 2020 }, function(err, result) {
+          should.not.exist(err);
+          const names = result.map((b) => b.name).sort();
+          should(names).eql(["WN2020", "WN2030"]);
+          bddone();
+        });
+      });
+
+      it("should only apply maxBlogNumber when minBlogNumber is omitted", function(bddone) {
+        blogModule.findBlogsForOutstandingExport("HugoDownload", ["DE"], { maxBlogNumber: 2020 }, function(err, result) {
+          should.not.exist(err);
+          const names = result.map((b) => b.name).sort();
+          should(names).eql(["WN2010", "WN2020"]);
+          bddone();
+        });
+      });
+
+      it("should return all outstanding blogs when no range is given (backward compatible)", function(bddone) {
+        blogModule.findBlogsForOutstandingExport("HugoDownload", ["DE"], function(err, result) {
+          should.not.exist(err);
+          should(result.length).equal(3);
+          bddone();
+        });
+      });
+    });
   });
 
   describe("buildOutstandingExportZip", function() {

--- a/test/model.blog.test.js
+++ b/test/model.blog.test.js
@@ -934,6 +934,50 @@ describe("model/blog", function() {
         bddone();
       });
     });
+
+    it("should continue past a failing language of one blog to both other languages and the next blog", function(bddone) {
+      testutil.importData({
+        clear: true,
+        blog: [
+          { name: "WN256", status: "edit", categories: [{ EN: "Mapping", DE: "Mapping" }], closeDE: true, closeEN: true },
+          { name: "WN255", status: "edit", categories: [{ EN: "Mapping", DE: "Mapping" }], closeDE: true }
+        ],
+        article: [
+          { blog: "WN256", title: "Article 256", markdownDE: "* Article 256 DE", markdownEN: "* Article 256 EN", category: "Mapping" },
+          { blog: "WN255", title: "Article 255", markdownDE: "* Article 255 DE", category: "Mapping" }
+        ]
+      }, function(err) {
+        should.not.exist(err);
+
+        // Only WN256/EN fails to render - WN256/DE (processed first) and
+        // WN255/DE (the next blog) must still make it through.
+        const originalCreateRenderer = blogRenderer.createRenderer;
+        sinon.stub(blogRenderer, "createRenderer").callsFake(function(type, blog, options) {
+          const realRenderer = originalCreateRenderer(type, blog, options);
+          return {
+            renderBlog(lang, data, createEmptyForOpenLanguage) {
+              if (blog.name === "WN256" && lang === "EN") {
+                throw new Error("Simulated render failure for WN256/EN");
+              }
+              return realRenderer.renderBlog(lang, data, createEmptyForOpenLanguage);
+            }
+          };
+        });
+
+        blogModule.buildOutstandingExportZip("HugoDownload", ["DE", "EN"], function(err, result) {
+          should.not.exist(err);
+          should.exist(result.archive);
+
+          should(result.failures.length).equal(1);
+          should(result.failures[0].blog.name).equal("WN256");
+          should(result.failures[0].lang).equal("EN");
+
+          const marked = result.toMark.map((m) => `${m.blog.name}:${m.lang}`).sort();
+          should(marked).eql(["WN255:DE", "WN256:DE"]);
+          bddone();
+        });
+      });
+    });
   });
 
   describe("markAsExported", function() {

--- a/test/notification.exportReceiver.test.js
+++ b/test/notification.exportReceiver.test.js
@@ -1,0 +1,87 @@
+
+
+
+import should from "should";
+import sinon from "sinon";
+
+import ExportReceiver from "../notification/exportReceiver.js";
+import { ExportLogWriterForTestOnly } from "../notification/exportLogWriter.js";
+
+describe("notification/exportReceiver", function () {
+  let receiver;
+  let infoStub;
+
+  beforeEach(function (bddone) {
+    receiver = new ExportReceiver();
+    infoStub = sinon.stub(ExportLogWriterForTestOnly.logger, "info");
+    return bddone();
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("should log to the export log when the change touches exportedBy", function (bddone) {
+    const user = { OSMUser: "apikey:hugoPipeline" };
+    const blog = { name: "WN1234", exportedBy: {} };
+    const change = { exportedBy: { HugoDownload: { DE: "2026-01-01T00:00:00.000Z" } } };
+
+    receiver.updateBlog(user, blog, change, function (err) {
+      should.not.exist(err);
+      should(infoStub.calledOnce).be.True();
+      const entry = infoStub.getCall(0).args[0];
+      should(entry.user).equal("apikey:hugoPipeline");
+      should(entry.blog).equal("WN1234");
+      should(entry.exportProfile).equal("HugoDownload");
+      should(entry.lang).equal("DE");
+      bddone();
+    });
+  });
+
+  it("should ignore changes that don't touch exportedBy", function (bddone) {
+    const user = { OSMUser: "editor" };
+    const blog = { name: "WN1234" };
+    const change = { status: "edit" };
+
+    receiver.updateBlog(user, blog, change, function (err) {
+      should.not.exist(err);
+      should(infoStub.called).be.False();
+      bddone();
+    });
+  });
+
+  it("should only log languages whose marker actually changed", function (bddone) {
+    const user = { OSMUser: "apikey:hugoPipeline" };
+    const blog = { name: "WN1234", exportedBy: { HugoDownload: { DE: "2025-01-01T00:00:00.000Z" } } };
+    const change = { exportedBy: { HugoDownload: { DE: "2025-01-01T00:00:00.000Z", EN: "2026-01-01T00:00:00.000Z" } } };
+
+    receiver.updateBlog(user, blog, change, function (err) {
+      should.not.exist(err);
+      should(infoStub.calledOnce).be.True();
+      should(infoStub.getCall(0).args[0].lang).equal("EN");
+      bddone();
+    });
+  });
+
+  it("should no-op every other receiver method", function (bddone) {
+    receiver.sendInfo({}, function (err) {
+      should.not.exist(err);
+      receiver.updateArticle({}, {}, {}, function (err) {
+        should.not.exist(err);
+        receiver.sendReviewStatus({}, {}, "DE", "ok", function (err) {
+          should.not.exist(err);
+          receiver.sendCloseStatus({}, {}, "DE", true, function (err) {
+            should.not.exist(err);
+            receiver.addComment({}, {}, "text", function (err) {
+              should.not.exist(err);
+              receiver.editComment({}, {}, 0, "text", function (err) {
+                should.not.exist(err);
+                bddone();
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/notification.filterReceiver.test.js
+++ b/test/notification.filterReceiver.test.js
@@ -1,0 +1,70 @@
+
+
+
+import should from "should";
+
+import FilterReceiver from "../notification/FilterReceiver.js";
+
+describe("notification/FilterReceiver", function () {
+  let dummy;
+  let called;
+  beforeEach(function (bddone) {
+    called = null;
+    dummy = {
+      updateBlog: function (user, blog, change, callback) {
+        called = { user, blog, change };
+        callback();
+      }
+    };
+    return bddone();
+  });
+
+  it("should forward to the wrapped receiver when the filter returns true", function (bddone) {
+    const fr = new FilterReceiver(dummy, { updateBlog: () => true });
+    fr.updateBlog({ OSMUser: "test" }, { name: "WN1" }, { status: "edit" }, function (err) {
+      should.not.exist(err);
+      should.exist(called);
+      should(called.change).eql({ status: "edit" });
+      bddone();
+    });
+  });
+
+  it("should skip the wrapped receiver when the filter returns false", function (bddone) {
+    const fr = new FilterReceiver(dummy, { updateBlog: () => false });
+    fr.updateBlog({ OSMUser: "test" }, { name: "WN1" }, { status: "edit" }, function (err) {
+      should.not.exist(err);
+      should(called).be.null();
+      bddone();
+    });
+  });
+
+  it("should pass the actual event arguments to the filter predicate", function (bddone) {
+    let receivedArgs = null;
+    const fr = new FilterReceiver(dummy, {
+      updateBlog: (...args) => {
+        receivedArgs = args;
+        return true;
+      }
+    });
+    fr.updateBlog({ OSMUser: "test" }, { name: "WN1" }, { status: "edit" }, function (err) {
+      should.not.exist(err);
+      should(receivedArgs.length).equal(3);
+      should(receivedArgs[2]).eql({ status: "edit" });
+      bddone();
+    });
+  });
+
+  it("should pass methods without a configured filter through unfiltered", function (bddone) {
+    dummy.sendInfo = function (object, callback) {
+      called = { object };
+      callback();
+    };
+    const fr = new FilterReceiver(dummy, { updateBlog: () => false });
+    fr.sendInfo({ some: "data" }, function (err) {
+      should.not.exist(err);
+      should.exist(called);
+      should(called.object).eql({ some: "data" });
+      bddone();
+    });
+  });
+});

--- a/test/notification.slackReceiver.test.js
+++ b/test/notification.slackReceiver.test.js
@@ -203,6 +203,26 @@ describe("notification/slackReceiver", function() {
       compactErrorLine.should.not.match(/nativeProtocols|_redirectable|_headerSent|\[Circular\]/);
     });
 
+    it("should not slack when an unrelated field changes (e.g. the exportedBy export marker)", function (bddone) {
+      const receiver = new SlackReceiver("test", "osmde", "#osmbcblog");
+      let sendCalled = false;
+      receiver.slack = {
+        send(_message, cb) {
+          sendCalled = true;
+          cb();
+        }
+      };
+      receiver.updateBlog(
+        { OSMUser: "testuser" },
+        { name: "WN251", status: "edit" },
+        { exportedBy: { HugoDownload: { DE: "2026-01-01T00:00:00.000Z" } } },
+        function (err) {
+          should.not.exist(err);
+          should(sendCalled).be.False();
+          bddone();
+        });
+    });
+
     it("should slack message when creating a blog", function (bddone) {
       const slack1 = nock("https://missingmattermost.example.com")
         .post("/services/osmde",

--- a/test/routes.api.test.js
+++ b/test/routes.api.test.js
@@ -473,6 +473,53 @@ describe("router/api", function() {
         should(blog3000.exportedBy).be.undefined();
       });
 
+      it("should narrow the dryRun listing to minBlogNumber/maxBlogNumber", async function() {
+        const response = await axios.get(
+          baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload&lang=DE&dryRun=true&minBlogNumber=3001&maxBlogNumber=3001",
+          { validateStatus: (status) => true }
+        );
+
+        should(response.status).eql(200);
+        should(response.data.minBlogNumber).eql(3001);
+        should(response.data.maxBlogNumber).eql(3001);
+        should(response.data.count).eql(1);
+        should(response.data.blogs.map((b) => b.name)).eql(["WN3001"]);
+      });
+
+      it("should only export blogs within the given WN range", async function() {
+        const response = await axios.get(
+          baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload&lang=DE&minBlogNumber=3001&maxBlogNumber=3001",
+          { validateStatus: (status) => true, responseType: "arraybuffer" }
+        );
+
+        should(response.status).eql(200);
+        const zipText = Buffer.from(response.data).toString("latin1");
+        zipText.should.containEql("de/archives/3001.md");
+        zipText.should.not.containEql("de/archives/3000.md");
+
+        await waitUntilExported("WN3001", "HugoDownload", "DE");
+        const blog3000 = await blogModule.findOne({ name: "WN3000" });
+        should(blog3000.exportedBy).be.undefined();
+      });
+
+      it("should reject a non-numeric minBlogNumber with 422", async function() {
+        const response = await axios.get(
+          baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload&minBlogNumber=notanumber",
+          { validateStatus: (status) => true }
+        );
+        should(response.status).eql(422);
+        should(response.data).containEql("minBlogNumber");
+      });
+
+      it("should reject minBlogNumber greater than maxBlogNumber with 422", async function() {
+        const response = await axios.get(
+          baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload&minBlogNumber=3001&maxBlogNumber=3000",
+          { validateStatus: (status) => true }
+        );
+        should(response.status).eql(422);
+        should(response.data).containEql("minBlogNumber");
+      });
+
       it("should reject a second concurrent outstanding export for the same profile with 409", async function() {
         const requestOptions = { validateStatus: (status) => true, responseType: "arraybuffer" };
         const url = baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload&lang=DE";

--- a/test/routes.api.test.js
+++ b/test/routes.api.test.js
@@ -2,14 +2,33 @@
 
 import async from "async";
 import should from "should";
+import sinon from "sinon";
 import config from "../config.js";
 import articleModule from "../model/article.js";
+import blogModule from "../model/blog.js";
+import blogRenderer from "../render/BlogRenderer.js";
 import nock from "nock";
 import axios from "axios";
 import initialiseModules from "../util/initialise.js";
 
 
 import testutil from "../test/testutil.js";
+
+// Polls the DB until the given blog has an exportedBy[profile][lang] marker
+// (the marker is set asynchronously after the download response finishes).
+async function waitUntilExported(name, profile, lang) {
+  const deadline = Date.now() + 2000;
+  for (;;) {
+    const blog = await blogModule.findOne({ name });
+    if (blog && blog.exportedBy && blog.exportedBy[profile] && blog.exportedBy[profile][lang]) {
+      return blog;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${name} to be marked as exported under ${profile}/${lang}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
 
 
 
@@ -351,6 +370,224 @@ describe("router/api", function() {
       should(response.status).eql(200);
       should(response.data).containEql("30.12.2024-06.01.2025");
       should(response.data).not.containEql("06.01.2025-13.01.2025");
+    });
+  });
+
+  describe("Blog preview download API for outstanding exports", function() {
+    describe("with no eligible blogs", function() {
+      it("should respond 404 (default noContentBehavior)", async function() {
+        const response = await axios.get(
+          baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload",
+          { validateStatus: (status) => true }
+        );
+        should(response.status).eql(404);
+      });
+
+      it("should respond with an empty zip when noContentBehavior=emptyZip", async function() {
+        const response = await axios.get(
+          baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=MarkdownDownload",
+          { validateStatus: (status) => true, responseType: "arraybuffer" }
+        );
+        should(response.status).eql(200);
+        should(response.headers["content-type"]).match(/application\/(zip|octet-stream)/);
+        const zipBuffer = Buffer.from(response.data);
+        zipBuffer.subarray(0, 2).toString("binary").should.eql("PK");
+      });
+    });
+
+    describe("with eligible closed blogs", function() {
+      beforeEach(function(bddone) {
+        testutil.importData({
+          clear: false,
+          blog: [
+            {
+              name: "WN3000",
+              status: "edit",
+              categories: [{ EN: "Mapping", DE: "Mapping" }],
+              closeDE: true,
+              closeEN: true
+            },
+            {
+              name: "WN3001",
+              status: "closed",
+              categories: [{ EN: "Mapping", DE: "Mapping" }],
+              closeDE: true,
+              closeEN: true
+            }
+          ],
+          article: [
+            {
+              blog: "WN3000",
+              title: "Outstanding article one",
+              markdownDE: "* Outstanding article one DE",
+              markdownEN: "* Outstanding article one EN",
+              category: "Mapping"
+            },
+            {
+              blog: "WN3001",
+              title: "Outstanding article two",
+              markdownDE: "* Outstanding article two DE",
+              markdownEN: "* Outstanding article two EN",
+              category: "Mapping"
+            }
+          ]
+        }, bddone);
+      });
+
+      it("should return a zip with one file per blog and mark both as exported", async function() {
+        const response = await axios.get(
+          baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload&lang=DE",
+          { validateStatus: (status) => true, responseType: "arraybuffer" }
+        );
+
+        should(response.status).eql(200);
+        should(response.headers["content-type"]).match(/application\/(zip|octet-stream)/);
+        const zipBuffer = Buffer.from(response.data);
+        zipBuffer.subarray(0, 2).toString("binary").should.eql("PK");
+        const zipText = zipBuffer.toString("latin1");
+        zipText.should.containEql("de/archives/3000.md");
+        zipText.should.containEql("de/archives/3001.md");
+
+        const blog3000 = await waitUntilExported("WN3000", "HugoDownload", "DE");
+        const blog3001 = await waitUntilExported("WN3001", "HugoDownload", "DE");
+        should.exist(blog3000.exportedBy.HugoDownload.DE);
+        should.exist(blog3001.exportedBy.HugoDownload.DE);
+      });
+
+      it("should list candidates via dryRun without marking or downloading anything", async function() {
+        const response = await axios.get(
+          baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload&lang=DE&dryRun=true",
+          { validateStatus: (status) => true }
+        );
+
+        should(response.status).eql(200);
+        should(response.headers["content-type"]).match(/application\/json/);
+        should(response.data.exportProfile).eql("HugoDownload");
+        should(response.data.count).eql(2);
+        const names = response.data.blogs.map((b) => b.name).sort();
+        should(names).eql(["WN3000", "WN3001"]);
+        response.data.blogs.forEach((b) => should(b.langs).eql(["DE"]));
+
+        // dryRun must not have any side effect
+        const blog3000 = await blogModule.findOne({ name: "WN3000" });
+        should(blog3000.exportedBy).be.undefined();
+      });
+
+      it("should reject a second concurrent outstanding export for the same profile with 409", async function() {
+        const requestOptions = { validateStatus: (status) => true, responseType: "arraybuffer" };
+        const url = baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload&lang=DE";
+        const [first, second] = await Promise.all([
+          axios.get(url, requestOptions),
+          axios.get(url, requestOptions)
+        ]);
+        const statuses = [first.status, second.status].sort();
+        should(statuses).eql([200, 409]);
+
+        // Wait out the winning request's async marking tail before the next
+        // test tears down/recreates the DB, otherwise its write lands on a
+        // dropped table.
+        await waitUntilExported("WN3001", "HugoDownload", "DE");
+      });
+
+      it("should skip a blog that fails to render, report it via a header and still export/mark the other", async function() {
+        const originalCreateRenderer = blogRenderer.createRenderer;
+        const stub = sinon.stub(blogRenderer, "createRenderer").callsFake(function(type, blog, options) {
+          if (blog.name === "WN3000") throw new Error("Simulated render failure");
+          return originalCreateRenderer(type, blog, options);
+        });
+
+        try {
+          const response = await axios.get(
+            baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload&lang=DE",
+            { validateStatus: (status) => true, responseType: "arraybuffer" }
+          );
+
+          should(response.status).eql(200);
+          should(response.headers["x-outstanding-export-warnings"]).eql("WN3000:DE");
+          const zipText = Buffer.from(response.data).toString("latin1");
+          zipText.should.not.containEql("de/archives/3000.md");
+          zipText.should.containEql("de/archives/3001.md");
+
+          const blog3001 = await waitUntilExported("WN3001", "HugoDownload", "DE");
+          should.exist(blog3001.exportedBy.HugoDownload.DE);
+          const blog3000 = await blogModule.findOne({ name: "WN3000" });
+          should(blog3000.exportedBy).be.undefined();
+        } finally {
+          stub.restore();
+        }
+      });
+
+      it("should still mark the other blog if one blog's marker fails to save", async function() {
+        const originalSave = blogModule.Class.prototype.save;
+        const stub = sinon.stub(blogModule.Class.prototype, "save").callsFake(function(cb) {
+          if (this.name === "WN3000") return cb(new Error("Simulated save failure"));
+          return originalSave.call(this, cb);
+        });
+
+        try {
+          const response = await axios.get(
+            baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload&lang=DE",
+            { validateStatus: (status) => true, responseType: "arraybuffer" }
+          );
+          should(response.status).eql(200);
+          const zipText = Buffer.from(response.data).toString("latin1");
+          zipText.should.containEql("de/archives/3000.md");
+          zipText.should.containEql("de/archives/3001.md");
+
+          // WN3001's marker must still be set even though WN3000's save failed
+          const blog3001 = await waitUntilExported("WN3001", "HugoDownload", "DE");
+          should.exist(blog3001.exportedBy.HugoDownload.DE);
+        } finally {
+          stub.restore();
+        }
+
+        // Once the stub is removed, WN3000 must still be "outstanding"
+        // (its marker never got saved) and reappear on the next dry run.
+        const dryRunResponse = await axios.get(
+          baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload&lang=DE&dryRun=true",
+          { validateStatus: (status) => true }
+        );
+        should(dryRunResponse.data.blogs.map((b) => b.name)).eql(["WN3000"]);
+      });
+
+      it("should respond 404 on a second download once all blogs are exported", async function() {
+        await axios.get(
+          baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload&lang=DE",
+          { validateStatus: (status) => true, responseType: "arraybuffer" }
+        );
+        await waitUntilExported("WN3001", "HugoDownload", "DE");
+
+        const secondResponse = await axios.get(
+          baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload&lang=DE",
+          { validateStatus: (status) => true }
+        );
+        should(secondResponse.status).eql(404);
+      });
+
+      it("should make a blog reappear after its language marker is reset via reopen/close", async function() {
+        await axios.get(
+          baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload&lang=DE",
+          { validateStatus: (status) => true, responseType: "arraybuffer" }
+        );
+        const blog3000 = await waitUntilExported("WN3000", "HugoDownload", "DE");
+
+        await new Promise((resolve, reject) => {
+          blog3000.closeBlog({ lang: "DE", user: { OSMUser: "user" }, status: false }, (err) => (err ? reject(err) : resolve()));
+        });
+        const reopened = await blogModule.findOne({ name: "WN3000" });
+        await new Promise((resolve, reject) => {
+          reopened.closeBlog({ lang: "DE", user: { OSMUser: "user" }, status: true }, (err) => (err ? reject(err) : resolve()));
+        });
+
+        const response = await axios.get(
+          baseLink + "/api/blogPreviewDownload/testapikey/outstanding?exportProfile=HugoDownload&lang=DE",
+          { validateStatus: (status) => true, responseType: "arraybuffer" }
+        );
+        should(response.status).eql(200);
+        const zipText = Buffer.from(response.data).toString("latin1");
+        zipText.should.containEql("de/archives/3000.md");
+        zipText.should.not.containEql("de/archives/3001.md");
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
Adds `GET /api/blogPreviewDownload/:apiKey/outstanding`: bulk-delivers every WeeklyNote blog that is closed for a language but not yet exported under a given `exportProfile`, bundled into a single ZIP, and marks each blog+lang as delivered afterwards.

- `dryRun=true` preview mode, no side effects
- `minBlogNumber`/`maxBlogNumber` paging through a large backlog
- Per-blog render-failure isolation (`X-Outstanding-Export-Warnings` header) instead of all-or-nothing
- In-process lock per `exportProfile` (409 on overlap)
- Marker set via the normal `setAndSave`/`messageCenter` path, filtered so it doesn't pollute the editorial change-log or trigger mail/Slack notifications, but is recorded in a separate rotating export log (`notification/exportLogWriter.js`)
- New `docs/API.md` (moved from repo root) + `docs/export-profiles.md` documenting the `ExportProfiles` config fields

See `CLAUDE.local.md` on this branch for full design/retrospective notes.

## Test plan
- `npx mocha` full suite run locally: passing, no regressions (per user confirmation before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)