### PR TITLE
fix: remove language code from hugo aliases

### DIFF
--- a/docs/hugo-export.md
+++ b/docs/hugo-export.md
@@ -10,20 +10,20 @@ looks like this:
 date = 2024-01-07
 draft = false
 title = '''weeklyOSM 703'''
-aliases = ['/archives/16247', '/en/archives/16247']
+aliases = ['/archives/16247']
 featureImage = '''https://example.com/lead.png'''
 featureImageCap = '''[¹](#wn703_12345) the lead picture'''
 +++
 ```
 
-| Field | Source | Notes |
-|---|---|---|
-| `date` | `blog.endDate` + `Hugo.DateAdjust` days, in `Europe/Berlin`, as `YYYY-MM-DD` | `DateAdjust` is a config knob (see [docs/config.md](config.md)); it shifts the collection end date forward to the intended publication date. |
-| `draft` | always `false` | |
-| `title` | `"<blog title for export> <issue number>"` | Blog title per language from `categorytranslation` (the row whose `EN` equals `"Blog Title For Export"`), issue number from `blog.name.substring(2,10)`. |
-| `aliases` | `slugalias.json` — see below | Omitted entirely when the issue has no mapping. |
-| `featureImage` | first Picture-category article's image URL | Omitted when there is no lead picture. |
-| `featureImageCap` | that article's caption markdown | `^text^` superscript is folded to Unicode characters here — front matter runs no shortcodes, unlike the content body. Omitted when empty. |
+| Field             | Source                                                                       | Notes                                                                                                                                                    |
+| ----------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `date`            | `blog.endDate` + `Hugo.DateAdjust` days, in `Europe/Berlin`, as `YYYY-MM-DD` | `DateAdjust` is a config knob (see [docs/config.md](config.md)); it shifts the collection end date forward to the intended publication date.             |
+| `draft`           | always `false`                                                               |                                                                                                                                                          |
+| `title`           | `"<blog title for export> <issue number>"`                                   | Blog title per language from `categorytranslation` (the row whose `EN` equals `"Blog Title For Export"`), issue number from `blog.name.substring(2,10)`. |
+| `aliases`         | `slugalias.json` — see below                                                 | Omitted entirely when the issue has no mapping.                                                                                                          |
+| `featureImage`    | first Picture-category article's image URL                                   | Omitted when there is no lead picture.                                                                                                                   |
+| `featureImageCap` | that article's caption markdown                                              | `^text^` superscript is folded to Unicode characters here — front matter runs no shortcodes, unlike the content body. Omitted when empty.                |
 
 Empty optional lines are dropped, not emitted as blank lines.
 
@@ -52,13 +52,13 @@ WordPress post id:
 
 ```json
 {
-  "219": 214,
-  "703": 16247,
-  "841": 18849
+    "219": 214,
+    "703": 16247,
+    "841": 18849
 }
 ```
 
-- Covers the **weeklyosm.eu era only** (WN 219–841 at the time of writing).
+- Covers the **wordpress era only** (WN 219–841 at the time of writing).
   Gaps exist for issue numbers that were never published on weeklyosm.eu.
 - Issues **before** WN 219 (the old `blog.openstreetmap.de` era, slug-based
   URLs on a different domain) are deliberately **out of scope** — those
@@ -69,19 +69,7 @@ WordPress post id:
 
 ### What gets emitted
 
-For an issue in the map with post id `P`, rendered in language `L`:
-
-| Language | `aliases` line |
-|---|---|
-| `EN` | `aliases = ['/archives/P', '/en/archives/P']` |
-| any other | `aliases = ['/<segment>/archives/P']` |
-
-`<segment>` is `language.wpExportName(L).toLowerCase()`. Brazilian Portuguese
-gets a **second** alias for a historical segment:
-
-| OSMBC language id | URL segments | why |
-|---|---|---|
-| `BR` | `br`, `pb` | weeklyosm.eu served Brazilian Portuguese under `/pb/` until the qtranslate language code was renamed to `br` (~mid-2024, matching OSMBC's id). qtranslate recomputes every permalink from the current config, so the whole archive now also answers under `/br/`. Both forms exist in old newsletters / external links, so both are aliased. |
+For an issue in the map with post id `P`: `aliases = ['/archives/P']`
 
 The alias is emitted for **every language OSMBC exports for the issue**.
 If a language did not exist on weeklyosm.eu back then, its alias simply

--- a/render/HugoMarkdownRenderer.js
+++ b/render/HugoMarkdownRenderer.js
@@ -6,7 +6,6 @@ import MarkdownRenderer from "./MarkdownRenderer.js";
 import util from "../util/util.js";
 import config from "../config.js";
 import configModule from "../model/config.js";
-import language from "../model/language.js";
 
 const debug = _debug("OSMBC:render:HugoMarkdownRenderer");
 
@@ -22,21 +21,10 @@ const dateAdjust = Number(config.getValue("Hugo", "DateAdjust", { mustExist: tru
 // that is missing here simply gets no alias.
 let slugAliasMap = {};
 try {
-  slugAliasMap = JSON.parse(readFileSync(path.resolve(config.getDirName(), "data", "slugalias.json"), "UTF8"));
+    slugAliasMap = JSON.parse(readFileSync(path.resolve(config.getDirName(), "data", "slugalias.json"), "UTF8"));
 } catch (err) {
-  debug("no usable data/slugalias.json: %s", err.message);
+    debug("no usable data/slugalias.json: %s", err.message);
 }
-
-// OSMBC language id -> extra historical weeklyosm.eu URL segments to alias on
-// top of the default one (language.wpExportName(lang).toLowerCase()).
-//
-// Brazilian Portuguese: weeklyosm.eu served it under /pb/ from the start
-// (qtranslate language code "pb", roughly WN 219 - 735). Around mid-2024 the
-// code was renamed to "br" (matching OSMBC's own id) and qtranslate recomputes
-// every permalink from the current config, so today the whole archive answers
-// under /br/archives/<id> too. Emit both so links from either era keep working
-// after the Hugo migration.
-const WP_ARCHIVE_EXTRA_SEGMENTS = { BR: ["pb"] };
 
 // ASCII -> Unicode superscript character, for places that can't use a Hugo
 // shortcode (front matter TOML strings never run shortcodes - see
@@ -51,265 +39,301 @@ const WP_ARCHIVE_EXTRA_SEGMENTS = { BR: ["pb"] };
 // (e.g. the brackets in the "[^[1]^]" footnote variant) is left unchanged
 // rather than dropped.
 const SUPERSCRIPT_UNICODE_MAP = {
-  0: "⁰", 1: "¹", 2: "²", 3: "³", 4: "⁴", 5: "⁵", 6: "⁶", 7: "⁷", 8: "⁸", 9: "⁹",
-  "+": "⁺", "-": "⁻", "=": "⁼", "(": "⁽", ")": "⁾",
-  a: "ᵃ", b: "ᵇ", c: "ᶜ", d: "ᵈ", e: "ᵉ", f: "ᶠ", g: "ᵍ", h: "ʰ", i: "ⁱ", j: "ʲ",
-  k: "ᵏ", l: "ˡ", m: "ᵐ", n: "ⁿ", o: "ᵒ", p: "ᵖ", r: "ʳ", s: "ˢ", t: "ᵗ",
-  u: "ᵘ", v: "ᵛ", w: "ʷ", x: "ˣ", y: "ʸ", z: "ᶻ"
+    0: "⁰",
+    1: "¹",
+    2: "²",
+    3: "³",
+    4: "⁴",
+    5: "⁵",
+    6: "⁶",
+    7: "⁷",
+    8: "⁸",
+    9: "⁹",
+    "+": "⁺",
+    "-": "⁻",
+    "=": "⁼",
+    "(": "⁽",
+    ")": "⁾",
+    a: "ᵃ",
+    b: "ᵇ",
+    c: "ᶜ",
+    d: "ᵈ",
+    e: "ᵉ",
+    f: "ᶠ",
+    g: "ᵍ",
+    h: "ʰ",
+    i: "ⁱ",
+    j: "ʲ",
+    k: "ᵏ",
+    l: "ˡ",
+    m: "ᵐ",
+    n: "ⁿ",
+    o: "ᵒ",
+    p: "ᵖ",
+    r: "ʳ",
+    s: "ˢ",
+    t: "ᵗ",
+    u: "ᵘ",
+    v: "ᵛ",
+    w: "ʷ",
+    x: "ˣ",
+    y: "ʸ",
+    z: "ᶻ",
 };
 
-
 class HugoMarkdownRenderer extends MarkdownRenderer {
-  /**
-   * Creates a new HugoMarkdownRenderer instance.
-   * Current implementation delegates all behavior to MarkdownRenderer.
-   * @param {object} blog - The blog object to render.
-  * @param {object} [options] - Optional renderer options.
-  * Currently accepted for API consistency and forwarded to MarkdownRenderer,
-  * but not used by HugoMarkdownRenderer-specific behavior.
-   */
-  constructor(blog, options) {
-    super(blog, options);
-  }
-
-  subtitle(lang) {
-    debug("HugoMarkdownRenderer.prototype.subtitle %s", lang);
-    return super.subtitle(lang);
-  }
-
-  _containsEmptyArticlesWarning(lang) {
-    debug("HugoMarkdownRenderer.prototype._containsEmptyArticlesWarning %s", lang);
-    return super._containsEmptyArticlesWarning(lang);
-  }
-
-  categoryTitle(lang, category) {
-    debug("HugoMarkdownRenderer.prototype.categoryTitle");
-    return super.categoryTitle(lang, category);
-  }
-
-  _renderArticleStandard(lang, article) {
-    let blogRef = article.blog;
-    if (!blogRef) blogRef = "undefined";
-    const pageLink = util.linkify(blogRef + "_" + article.id);
-
-    const md = this._renderMarkdownListItem(lang, article);
-
-    return `* {{< anchor "${pageLink}" >}} ${md}`;
-  }
-
-  /**
-   * Post-processes Hugo markdown to transform emoji shortcuts to Hugo icon shortcodes.
-   * Used when markdown is already in text form (not converted via HTML/Turndown).
-   * Semantik: Replaces markdown-level emoji shortcuts with Hugo icon shortcodes,
-   * similar to how the HTML-level emoji plugin works.
-   * @param {string} markdown - The markdown text to transform
-   * @returns {string} The transformed markdown
-   */
-  _transformHugoMarkdown(markdown) {
-    if (!markdown) return markdown;
-    let result = markdown;
-
-    // Get emoji configuration from languageflags
-    const languageFlags = configModule.getConfig("languageflags");
-    const shortcut = languageFlags.shortcut || {};
-    const emoji = languageFlags.emoji || {};
-
-    const toHugoEmoji = function(value) {
-      if (!value) return null;
-      // markdown-it-emoji defs may return an <img ...> snippet; extract src.
-      const imgMatch = String(value).match(/<img\s+[^>]*src=["']([^"']+)["'][^>]*>/i);
-      const src = imgMatch && imgMatch[1] ? imgMatch[1] : null;
-      const raw = src || String(value);
-
-      // Treat path-like or URL-like values as Hugo icon shortcodes.
-      if (raw.startsWith("/") || raw.startsWith("http://") || raw.startsWith("https://")) {
-        return `{{< icon "${raw}" >}}`;
-      }
-
-      // Otherwise keep as plain markdown text so Hugo can render unicode emojis.
-      return raw;
-    };
-
-    // Transform all configured emoji shortcuts.
-    Object.entries(shortcut).forEach(([emojiName, shortcutString]) => {
-      if (shortcutString && emoji[emojiName]) {
-        const replacement = toHugoEmoji(emoji[emojiName]);
-        if (replacement) {
-          result = result.replaceAll(shortcutString, replacement);
-        }
-      }
-    });
-
-    // Also support :emoji_name: style from markdown-it-emoji semantics.
-    Object.keys(emoji).forEach((emojiName) => {
-      const replacement = toHugoEmoji(emoji[emojiName]);
-      if (replacement) {
-        result = result.replaceAll(`:${emojiName}:`, replacement);
-      }
-    });
-
-    return result;
-  }
-
-  _renderArticlePicture(lang, article) {
-    return "";
-  }
-
-  _renderArticleUpcomingEvents(lang, article) {
-    let md = super._renderArticleUpcomingEvents(lang, article);
-    md = md.replaceAll("![flag](", "![](");
-    return md;
-  }
-
-  _renderMarkdownListItem(lang, article) {
-    let md = super._renderMarkdownListItem(lang, article);
-    md = this._replaceSuperscriptShortcode(md);
-    // Transform emoji shortcuts to Hugo icon shortcodes for markdown-level processing
-    md = this._transformHugoMarkdown(md);
-    return md;
-  }
-
-  /**
-   * Converts inline "^text^" superscript markdown (used editorially for
-   * footnote-style references like "^1^", ordinals like "1^er^"/"12^th^",
-   * link-language markers like "^en^", and exponents like "km^2^") into a
-   * Hugo "sup" shortcode. Hugo's own markdown engine (Goldmark) has no
-   * native superscript syntax, so this must run as a text pre-processing
-   * step before Hugo ever sees the markdown - only valid for regular
-   * content, never for front matter (TOML strings never run shortcodes,
-   * see _generateFrontText).
-   * Delimiter matching mirrors util/markdown-it-sup.js: a "^", then one or
-   * more characters that are neither whitespace nor "^", then the next
-   * "^". Excluding "^" itself from the captured run is what keeps a
-   * three-or-more-caret string ("^a^ ^b^") from being mis-paired across
-   * the wrong two carets - the match always closes at the very next "^".
-   * @param {string} text - Markdown text to transform
-   * @returns {string} The transformed markdown
-   */
-  _replaceSuperscriptShortcode(text) {
-    if (!text) return text;
-    return text.replace(/\^([^\s^]+)\^/g, (_match, content) => {
-      const escaped = content.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
-      return `{{< sup "${escaped}" >}}`;
-    });
-  }
-
-  /**
-   * Same "^text^" delimiter matching as _replaceSuperscriptShortcode, but
-   * resolves each character to its Unicode superscript equivalent
-   * (SUPERSCRIPT_UNICODE_MAP) instead of a Hugo shortcode - for use inside
-   * front matter (TOML strings), where shortcodes never run. A character
-   * with no superscript equivalent (uppercase letters, brackets, ...) is
-   * kept as-is rather than dropped.
-   * @param {string} text - Markdown text to transform
-   * @returns {string} The transformed text
-   */
-  _replaceSuperscriptUnicode(text) {
-    if (!text) return text;
-    return text.replace(/\^([^\s^]+)\^/g, (_match, content) => {
-      return content.replace(/./g, (ch) => SUPERSCRIPT_UNICODE_MAP[ch.toLowerCase()] || ch);
-    });
-  }
-
-  _renderArticleUnpublished(text, article) {
-    return super._renderArticleUnpublished(text, article);
-  }
-
-  articleTitle(lang, article) {
-    debug("HugoMarkdownRenderer.prototype.articleTitle");
-    return super.articleTitle(lang, article);
-  }
-
-  _listAroundArticles(categoryString) {
-    return super._listAroundArticles(categoryString);
-  }
-
-  _formatTeamString(teamstring) {
-    return super._formatTeamString(teamstring);
-  }
-
-  /**
-   * Hugo `aliases` for one issue/language: the old weeklyosm.eu WordPress
-   * permalinks that must keep redirecting to this page.
-   * @param {string} lang - OSMBC language id (e.g. "EN", "DE", "BR").
-   * @returns {string[]} Site-relative alias paths, or [] when the issue is not
-   * in slugalias.json (pre-weeklyosm.eu era, or a non-WN blog).
-   */
-  _archiveAliases(lang) {
-    const match = /^WN0*(\d+)$/.exec((this.blog && this.blog.name) || "");
-    if (!match) return [];
-    const postId = slugAliasMap[match[1]];
-    if (postId === undefined || postId === null) return [];
-    const segments = [language.wpExportName(lang).toLowerCase()].concat(WP_ARCHIVE_EXTRA_SEGMENTS[lang] || []);
-    const aliases = segments.map((segment) => { return "/" + segment + "/archives/" + postId; });
-    // English was the default language and also answered without a prefix.
-    if (lang === "EN") aliases.unshift("/archives/" + postId);
-    return aliases;
-  }
-
-  _generateFrontText(lang, pictureArticles) {
-    // generate TOML header for Hugo front matter
-    debug("HugoMarkdownRenderer.prototype._generateFrontText %s", lang);
-    const categoryTranslation = configModule.getConfig("categorytranslation");
-
-    const blogNames = (categoryTranslation.filter((category) => { return (category.EN === wpExpressTitle); }))[0];
-    const date = moment(this.blog.endDate).tz("Europe/Berlin").add(dateAdjust, "days").format("YYYY-MM-DD");
-    let pictureLink = null;
-    let pictureMd = null;
-    if (pictureArticles && pictureArticles.length > 0) {
-      const pictureArticle = pictureArticles[0];
-      const rawMd = pictureArticle["markdown" + lang];
-      const md = (rawMd) ? this._transformHugoMarkdown(rawMd) : null;
-
-      const regexMarkdownImage = /!\[([^\]]*)\]\(([^)]+)\)/;
-      const regexUrlFromCollection = /\b(https?:\/\/[^\[\]() \n\r]*)\b/g;
-      // "^text^" superscript markup can't use a Hugo shortcode here (front
-      // matter is raw TOML, never processed for shortcodes - unlike the
-      // content body, see _replaceSuperscriptShortcode), so it's resolved
-      // to plain Unicode superscript characters instead.
-      pictureMd = this._replaceSuperscriptUnicode(md);
-      if (pictureMd) {
-        pictureMd = pictureMd.replace(/\s*=\d+\s*[xX]\s*\d+(?=\))/g, "");
-        const imageMatch = regexMarkdownImage.exec(pictureMd);
-        if (imageMatch && imageMatch.length >= 3) {
-          pictureLink = imageMatch[2];
-          pictureMd = pictureMd.replace(regexMarkdownImage, "").trim();
-        } else {
-          const link = regexUrlFromCollection.exec(pictureMd);
-          if (link && link.length > 0) {
-            pictureLink = link[0];
-            pictureMd = pictureMd.replace(/!\[([^\]]*)\]\s*\(\s*[^)]*\)/g, "").trim();
-            if (pictureMd.includes(link[0])) {
-              pictureMd = pictureMd.replace(link[0], "").trim();
-            }
-          }
-        }
-      }
+    /**
+     * Creates a new HugoMarkdownRenderer instance.
+     * Current implementation delegates all behavior to MarkdownRenderer.
+     * @param {object} blog - The blog object to render.
+     * @param {object} [options] - Optional renderer options.
+     * Currently accepted for API consistency and forwarded to MarkdownRenderer,
+     * but not used by HugoMarkdownRenderer-specific behavior.
+     */
+    constructor(blog, options) {
+        super(blog, options);
     }
-    const title = (blogNames[lang] + " " + this.blog.name.substring(2,10));
-    const aliases = this._archiveAliases(lang);
 
-    const text = [
-      "+++",
-      "date = " + date,
-      "draft = false",
-      "title = '''" + title + "'''",
-      (aliases.length) ? "aliases = [" + aliases.map((a) => { return "'" + a + "'"; }).join(", ") + "]" : "",
-      (pictureLink) ? "featureImage = '''" + pictureLink + "'''" : "",
-      (pictureMd) ? "featureImageCap = '''" + pictureMd + "'''" : "",
-      "+++"
-    ].filter((line) => { return line !== ""; }).join("\n");
+    subtitle(lang) {
+        debug("HugoMarkdownRenderer.prototype.subtitle %s", lang);
+        return super.subtitle(lang);
+    }
 
-    return text + "\n\n";
-  }
+    _containsEmptyArticlesWarning(lang) {
+        debug("HugoMarkdownRenderer.prototype._containsEmptyArticlesWarning %s", lang);
+        return super._containsEmptyArticlesWarning(lang);
+    }
 
-  _renderMissingCategory(name, articles) {
-    return super._renderMissingCategory(name, articles);
-  }
+    categoryTitle(lang, category) {
+        debug("HugoMarkdownRenderer.prototype.categoryTitle");
+        return super.categoryTitle(lang, category);
+    }
 
-  renderBlog(lang, articleData, onlyClosed = false) {
-    return super.renderBlog(lang, articleData, onlyClosed);
-  }
+    _renderArticleStandard(lang, article) {
+        let blogRef = article.blog;
+        if (!blogRef) blogRef = "undefined";
+        const pageLink = util.linkify(blogRef + "_" + article.id);
+
+        const md = this._renderMarkdownListItem(lang, article);
+
+        return `* {{< anchor "${pageLink}" >}} ${md}`;
+    }
+
+    /**
+     * Post-processes Hugo markdown to transform emoji shortcuts to Hugo icon shortcodes.
+     * Used when markdown is already in text form (not converted via HTML/Turndown).
+     * Semantik: Replaces markdown-level emoji shortcuts with Hugo icon shortcodes,
+     * similar to how the HTML-level emoji plugin works.
+     * @param {string} markdown - The markdown text to transform
+     * @returns {string} The transformed markdown
+     */
+    _transformHugoMarkdown(markdown) {
+        if (!markdown) return markdown;
+        let result = markdown;
+
+        // Get emoji configuration from languageflags
+        const languageFlags = configModule.getConfig("languageflags");
+        const shortcut = languageFlags.shortcut || {};
+        const emoji = languageFlags.emoji || {};
+
+        const toHugoEmoji = function (value) {
+            if (!value) return null;
+            // markdown-it-emoji defs may return an <img ...> snippet; extract src.
+            const imgMatch = String(value).match(/<img\s+[^>]*src=["']([^"']+)["'][^>]*>/i);
+            const src = imgMatch && imgMatch[1] ? imgMatch[1] : null;
+            const raw = src || String(value);
+
+            // Treat path-like or URL-like values as Hugo icon shortcodes.
+            if (raw.startsWith("/") || raw.startsWith("http://") || raw.startsWith("https://")) {
+                return `{{< icon "${raw}" >}}`;
+            }
+
+            // Otherwise keep as plain markdown text so Hugo can render unicode emojis.
+            return raw;
+        };
+
+        // Transform all configured emoji shortcuts.
+        Object.entries(shortcut).forEach(([emojiName, shortcutString]) => {
+            if (shortcutString && emoji[emojiName]) {
+                const replacement = toHugoEmoji(emoji[emojiName]);
+                if (replacement) {
+                    result = result.replaceAll(shortcutString, replacement);
+                }
+            }
+        });
+
+        // Also support :emoji_name: style from markdown-it-emoji semantics.
+        Object.keys(emoji).forEach((emojiName) => {
+            const replacement = toHugoEmoji(emoji[emojiName]);
+            if (replacement) {
+                result = result.replaceAll(`:${emojiName}:`, replacement);
+            }
+        });
+
+        return result;
+    }
+
+    _renderArticlePicture(lang, article) {
+        return "";
+    }
+
+    _renderArticleUpcomingEvents(lang, article) {
+        let md = super._renderArticleUpcomingEvents(lang, article);
+        md = md.replaceAll("![flag](", "![](");
+        return md;
+    }
+
+    _renderMarkdownListItem(lang, article) {
+        let md = super._renderMarkdownListItem(lang, article);
+        md = this._replaceSuperscriptShortcode(md);
+        // Transform emoji shortcuts to Hugo icon shortcodes for markdown-level processing
+        md = this._transformHugoMarkdown(md);
+        return md;
+    }
+
+    /**
+     * Converts inline "^text^" superscript markdown (used editorially for
+     * footnote-style references like "^1^", ordinals like "1^er^"/"12^th^",
+     * link-language markers like "^en^", and exponents like "km^2^") into a
+     * Hugo "sup" shortcode. Hugo's own markdown engine (Goldmark) has no
+     * native superscript syntax, so this must run as a text pre-processing
+     * step before Hugo ever sees the markdown - only valid for regular
+     * content, never for front matter (TOML strings never run shortcodes,
+     * see _generateFrontText).
+     * Delimiter matching mirrors util/markdown-it-sup.js: a "^", then one or
+     * more characters that are neither whitespace nor "^", then the next
+     * "^". Excluding "^" itself from the captured run is what keeps a
+     * three-or-more-caret string ("^a^ ^b^") from being mis-paired across
+     * the wrong two carets - the match always closes at the very next "^".
+     * @param {string} text - Markdown text to transform
+     * @returns {string} The transformed markdown
+     */
+    _replaceSuperscriptShortcode(text) {
+        if (!text) return text;
+        return text.replace(/\^([^\s^]+)\^/g, (_match, content) => {
+            const escaped = content.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+            return `{{< sup "${escaped}" >}}`;
+        });
+    }
+
+    /**
+     * Same "^text^" delimiter matching as _replaceSuperscriptShortcode, but
+     * resolves each character to its Unicode superscript equivalent
+     * (SUPERSCRIPT_UNICODE_MAP) instead of a Hugo shortcode - for use inside
+     * front matter (TOML strings), where shortcodes never run. A character
+     * with no superscript equivalent (uppercase letters, brackets, ...) is
+     * kept as-is rather than dropped.
+     * @param {string} text - Markdown text to transform
+     * @returns {string} The transformed text
+     */
+    _replaceSuperscriptUnicode(text) {
+        if (!text) return text;
+        return text.replace(/\^([^\s^]+)\^/g, (_match, content) => {
+            return content.replace(/./g, (ch) => SUPERSCRIPT_UNICODE_MAP[ch.toLowerCase()] || ch);
+        });
+    }
+
+    _renderArticleUnpublished(text, article) {
+        return super._renderArticleUnpublished(text, article);
+    }
+
+    articleTitle(lang, article) {
+        debug("HugoMarkdownRenderer.prototype.articleTitle");
+        return super.articleTitle(lang, article);
+    }
+
+    _listAroundArticles(categoryString) {
+        return super._listAroundArticles(categoryString);
+    }
+
+    _formatTeamString(teamstring) {
+        return super._formatTeamString(teamstring);
+    }
+
+    /**
+     * Hugo `aliases` for one issue: the old weeklyosm.eu WordPress
+     * permalinks that must keep redirecting to this page.
+     * @returns {string[]} Site-relative alias paths, or [] when the issue is not
+     * in slugalias.json (pre-weeklyosm.eu era, or a non-WN blog).
+     */
+    _archiveAliases() {
+        const match = /^WN0*(\d+)$/.exec((this.blog && this.blog.name) || "");
+        if (!match) return [];
+        const postId = slugAliasMap[match[1]];
+        if (postId === undefined || postId === null) return [];
+        const aliases = "/archives/" + postId;
+        return aliases;
+    }
+
+    _generateFrontText(lang, pictureArticles) {
+        // generate TOML header for Hugo front matter
+        debug("HugoMarkdownRenderer.prototype._generateFrontText %s", lang);
+        const categoryTranslation = configModule.getConfig("categorytranslation");
+
+        const blogNames = categoryTranslation.filter((category) => {
+            return category.EN === wpExpressTitle;
+        })[0];
+        const date = moment(this.blog.endDate).tz("Europe/Berlin").add(dateAdjust, "days").format("YYYY-MM-DD");
+        let pictureLink = null;
+        let pictureMd = null;
+        if (pictureArticles && pictureArticles.length > 0) {
+            const pictureArticle = pictureArticles[0];
+            const rawMd = pictureArticle["markdown" + lang];
+            const md = rawMd ? this._transformHugoMarkdown(rawMd) : null;
+
+            const regexMarkdownImage = /!\[([^\]]*)\]\(([^)]+)\)/;
+            const regexUrlFromCollection = /\b(https?:\/\/[^\[\]() \n\r]*)\b/g;
+            // "^text^" superscript markup can't use a Hugo shortcode here (front
+            // matter is raw TOML, never processed for shortcodes - unlike the
+            // content body, see _replaceSuperscriptShortcode), so it's resolved
+            // to plain Unicode superscript characters instead.
+            pictureMd = this._replaceSuperscriptUnicode(md);
+            if (pictureMd) {
+                pictureMd = pictureMd.replace(/\s*=\d+\s*[xX]\s*\d+(?=\))/g, "");
+                const imageMatch = regexMarkdownImage.exec(pictureMd);
+                if (imageMatch && imageMatch.length >= 3) {
+                    pictureLink = imageMatch[2];
+                    pictureMd = pictureMd.replace(regexMarkdownImage, "").trim();
+                } else {
+                    const link = regexUrlFromCollection.exec(pictureMd);
+                    if (link && link.length > 0) {
+                        pictureLink = link[0];
+                        pictureMd = pictureMd.replace(/!\[([^\]]*)\]\s*\(\s*[^)]*\)/g, "").trim();
+                        if (pictureMd.includes(link[0])) {
+                            pictureMd = pictureMd.replace(link[0], "").trim();
+                        }
+                    }
+                }
+            }
+        }
+        const title = blogNames[lang] + " " + this.blog.name.substring(2, 10);
+        const alias = this._archiveAliases();
+
+        const text = [
+            "+++",
+            "date = " + date,
+            "draft = false",
+            "title = '''" + title + "'''",
+            alias ? "aliases = ['" + alias + "']" : "",
+            pictureLink ? "featureImage = '''" + pictureLink + "'''" : "",
+            pictureMd ? "featureImageCap = '''" + pictureMd + "'''" : "",
+            "+++",
+        ]
+            .filter((line) => {
+                return line !== "";
+            })
+            .join("\n");
+
+        return text + "\n\n";
+    }
+
+    _renderMissingCategory(name, articles) {
+        return super._renderMissingCategory(name, articles);
+    }
+
+    renderBlog(lang, articleData, onlyClosed = false) {
+        return super.renderBlog(lang, articleData, onlyClosed);
+    }
 }
 
 export default HugoMarkdownRenderer;

--- a/test/data/render.blog.preview.6.md
+++ b/test/data/render.blog.preview.6.md
@@ -2,7 +2,7 @@
 date = 2015-02-10
 draft = false
 title = '''Wochennotiz 823'''
-aliases = ['/de/archives/18550']
+aliases = ['/archives/18550']
 featureImage = '''https://bild.irgendwo/foto.png'''
 featureImageCap = '''[¹](#wn815_34170) verweist auf das bild'''
 +++

--- a/test/render.blogrenderer.test.js
+++ b/test/render.blogrenderer.test.js
@@ -1,7 +1,3 @@
-
-
-
-
 import should from "should";
 import testutil from "./testutil.js";
 
@@ -17,842 +13,915 @@ import BlogRenderer from "../render/BlogRenderer.js";
 import Renderer from "../render/Renderer.js";
 import config from "../config.js";
 
+describe("render/blogrenderer", function () {
+    let renderer;
+    before(async function () {
+        await configModule.initialise();
+        renderer = BlogRenderer.createRenderer("HTML");
+        nock("https://missingmattermost.example.com/")
+            .post(/\/services\/.*/)
+            .times(999)
+            .reply(200, "ok");
 
-
-
-
-
-
-
-describe("render/blogrenderer", function() {
-  let renderer;
-  before(async function () {
-    await configModule.initialise();
-    renderer = BlogRenderer.createRenderer("HTML");
-    nock("https://missingmattermost.example.com/")
-      .post(/\/services\/.*/)
-      .times(999)
-      .reply(200, "ok");
-
-    process.env.TZ = "Europe/Amsterdam";
-    await testutil.clearDB();
-  });
-  after(function (bddone) {
-    nock.cleanAll();
-    bddone();
-  });
-
-
-  describe("htmlArticle", function() {
-    it("should generate a preview when no markdown is specified (no Edit Link)", function (bddone) {
-      const article = articleModule.create({ title: "Test Title" });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\nTest Title\n</li>\n');
-      bddone();
+        process.env.TZ = "Europe/Amsterdam";
+        await testutil.clearDB();
     });
-    it("should generate a preview when no markdown2 is specified (no Edit Link)", function (bddone) {
-      const article = articleModule.create({ collection: "Test Collection" });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\nTest Collection\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview when no markdown2 is specified (Edit Link)", function (bddone) {
-      const article = articleModule.create({ collection: "Test Collection" });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\nTest Collection\n</li>\n');
-      bddone();
-    });
-    it("should indent all leading asterisks in multiline article content", function (bddone) {
-      // Result is broken as "* " in the beginnin of an article is removed
-      // so double * are not allowed yet. They do not make sense imho TheFive
-      const article = articleModule.create({
-        markdownDE: "* line one\n* line two\n* line three",
-        id: 5,
-        blog: "TEST"
-      });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal("<li id=\"test_5\">\n<p>line one</p>\n<ul>\n<li>line two</li>\n<li>line three</li>\n</ul>\n</li>\n");
-      bddone();
-    });
-    it("should generate a preview when markdown is specified (Edit Link) (editor mode)", function (bddone) {
-      const renderer = BlogRenderer.createRenderer("HTML", null, { target: "editor" });
-      const article = articleModule.create({ markdownDE: "[Paul](https://test.link.de) tells something about [nothing](www.nothing.de)." });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\n<a href="https://test.link.de" target="_blank" rel="noopener">Paul</a> tells something about <a href="www.nothing.de" target="_blank" rel="noopener">nothing</a>.\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview when markdown is specified (Edit Link) (production mode)", function (bddone) {
-      const renderer = BlogRenderer.createRenderer("HTML", null, { target: "production" });
-      const article = articleModule.create({ markdownDE: "[Paul](https://test.link.de) tells something about [nothing](www.nothing.de)." });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\n<a href="https://test.link.de" class="production">Paul</a> tells something about <a href="www.nothing.de" class="production">nothing</a>.\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview when markdown is specified (Translate Link Required)", function (bddone) {
-      const article = articleModule.create({ markdownDE: "[Paul](https://test.link.de) tells something about [nothing](www.nothing.de)." });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\n<a href="https://test.link.de">Paul</a> tells something about <a href="www.nothing.de">nothing</a>.\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview when markdown is specified (with Star)", function (bddone) {
-      const article = articleModule.create({ markdownDE: "* [Paul](https://test.link.de) tells something about [nothing](www.nothing.de)." });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\n<a href="https://test.link.de">Paul</a> tells something about <a href="www.nothing.de">nothing</a>.\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview with a comment and no status", function (bddone) {
-      const article = articleModule.create({ markdownDE: "small markdown", commentList: [{ text: "Hallo" }], commentRead: { TheFive: 0 } });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\nsmall markdown\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview with a comment and open status", function (bddone) {
-      const article = articleModule.create({ markdownDE: "small markdown", commentList: [{ text: "Hallo" }], commentStatus: "open", commentRead: { TheFive: 0 } });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\nsmall markdown\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview with a comment and open status checking Marktext", function (bddone) {
-      const article = articleModule.create({ markdownDE: "small markdown", commentList: [{ text: "Hallo" }], commentStatus: "open" });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id=\"undefined_0\">\nsmall markdown\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview (no markdown) with a comment and open status", function (bddone) {
-      const article = articleModule.create({ collection: "small collection", commentList: [{ text: "Hallo @EN" }], commentStatus: "open", commentRead: { TheFive: 0 } });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\nsmall collection\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview (no markdown) with a comment and open status case insensitive test", function (bddone) {
-      const article = articleModule.create({ collection: "small collection", commentList: [{ text: "Hallo @en" }], commentStatus: "open", commentRead: { PaulFromMars: 0 } });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\nsmall collection\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview with a comment and open status and reference for all user", function (bddone) {
-      const article = articleModule.create({ markdownDE: "small markdown", commentList: [{ text: "Hallo @all" }], commentStatus: "open", commentRead: { TheFive: 0 } });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\nsmall markdown\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview with a comment and open status and reference for a specific user", function (bddone) {
-      const article = articleModule.create({ markdownDE: "small markdown", commentList: [{ text: "Hallo @user" }], commentStatus: "open" });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\nsmall markdown\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview with a comment and open status and reference for a specific language", function (bddone) {
-      const article = articleModule.create({ markdownDE: "small markdown", commentList: [{ text: "simpel text" }, { text: "Hallo @DE" }, { text: "dudeldü" }], commentStatus: "open", commentRead: { user: 0 } });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\nsmall markdown\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview with a comment and solved status", function (bddone) {
-      const article = articleModule.create({ markdownDE: "small markdown", commentList: [{ text: "solved" }], commentStatus: "solved" });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\nsmall markdown\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview Github Error #102 in german", function (bddone) {
-      const article = articleModule.create({ markdownDE: "Howto place an issue in OSMBC? \n1. open OSMBC, \n1. click Collect,\n1. choose a category from the pop up window\n1. write a Titel: example: Lidar,\n1. write at text or put a link\n1. click OK\n--- reday --- \n\nIf you like to write the news directly, do as follows:\n\n1. click Edit\n2. write your news in English (you can see it in \n3. click OK and ...\n... that's it.", commentList: [{ text: "Hallo" }], commentStatus: "solved" });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id="undefined_0">\n<p>Howto place an issue in OSMBC?</p>\n<ol>\n<li>open OSMBC,</li>\n<li>click Collect,</li>\n<li>choose a category from the pop up window</li>\n<li>write a Titel: example: Lidar,</li>\n<li>write at text or put a link</li>\n<li>click OK\n--- reday ---</li>\n</ol>\n<p>If you like to write the news directly, do as follows:</p>\n<ol>\n<li>click Edit</li>\n<li>write your news in English (you can see it in</li>\n<li>click OK and ...\n... that\'s it.</li>\n</ol>\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview Github Error #102 in english", function (bddone) {
-      const article = articleModule.create({ markdownEN: "Howto place an issue in OSMBC? \n1. open OSMBC, \n1. click Collect,\n1. choose a category from the pop up window\n1. write a Titel: example: Lidar,\n1. write at text or put a link\n1. click OK\n--- reday --- \n\nIf you like to write the news directly, do as follows:\n1. click Edit\n2. write your news in English (you can see it in \n3. click OK and ...\n... that's it.", commentList: [{ text: "Hallo" }], commentStatus: "solved" });
-      const result = renderer.renderArticle("EN", article);
-      should(result).equal('<li id="undefined_0">\n<p>Howto place an issue in OSMBC?</p>\n<ol>\n<li>open OSMBC,</li>\n<li>click Collect,</li>\n<li>choose a category from the pop up window</li>\n<li>write a Titel: example: Lidar,</li>\n<li>write at text or put a link</li>\n<li>click OK\n--- reday ---</li>\n</ol>\n<p>If you like to write the news directly, do as follows:</p>\n<ol>\n<li>click Edit</li>\n<li>write your news in English (you can see it in</li>\n<li>click OK and ...\n... that\'s it.</li>\n</ol>\n</li>\n');
-      bddone();
-    });
-    it("should generate a preview for a picture", function (bddone) {
-      const article = articleModule.create({
-        markdownEN: "![Alternative Text](https://osmbc.com/picture.jpg =300x200)\n\nSome caption text allowing superscript [^[1]^](#WN271_wetterabhängige_Karte)",
-        categoryEN: "Picture",
-        commentList: [{ text: "Hallo" }],
-        commentStatus: "solved"
-      });
-      const result = renderer.renderArticle("EN", article);
-      should(result).equal('<div style="width: 310px" class="wp-caption alignnone"> \n<p class="wp-caption-text"><img src="https://osmbc.com/picture.jpg" alt="Alternative Text" width="300" height="200"></p>\n<p class="wp-caption-text">Some caption text allowing superscript <a href="#WN271_wetterabh%C3%A4ngige_Karte"><sup>[1]</sup></a></p>\n</div>\n');
-      bddone();
-    });
-    it("should generate a preview for a translation", function (bddone) {
-      const article = articleModule.create({
-        markdownEN: "We will tell you something about maps.",
-        markdownDE: "Wir erzählen euch was über Karten.",
-        categoryEN: "Maps",
-        commentList: [{ text: "Hallo" }],
-        commentStatus: "solved"
-      });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<li id=\"undefined_0\">\nWir erzählen euch was über Karten.\n</li>\n');
-      bddone();
-    });
-    it("should generate an article for Upcoming Events", function (bddone) {
-      const article = articleModule.create({
-        markdownEN: "This is a table",
-        markdownDE: "Eine Tabelle",
-        categoryEN: "Upcoming Events"
-      });
-      const result = renderer.renderArticle("DE", article);
-      should(result).equal('<p>Eine Tabelle\n</p>\n<p>Hinweis:<br />Wer seinen Termin hier in der Liste sehen möchte, <a href=\"https://wiki.openstreetmap.org/wiki/Template:Calendar\">trage</a> ihn in den <a href=\"https://wiki.openstreetmap.org/wiki/Current_events\">Kalender</a> ein. Nur Termine, die dort stehen, werden in die Wochennotiz übernommen.</p>\n');
-      bddone();
-    });
-    it("should work with Emojies", function (bddone) {
-      const article = articleModule.create({
-        markdownEN: "Greetings from [:germany:](https://en.wikipedia.org/wiki/Germany) :-)",
-        categoryEN: "Maps"
-      });
-      const result = renderer.renderArticle("EN", article);
-      should(result).equal('<li id="undefined_0">\nGreetings from <a href="https://en.wikipedia.org/wiki/Germany"><img src=\"/localMediaFOlder2015/de-black.svg\" /></a> 😃\n</li>\n');
-      bddone();
-    });
-    it("should handle unpublished picture article with reason", function (bddone) {
-      const article = articleModule.create({
-        markdownEN: "![Alt Text](https://example.com/pic.jpg =300x200)\n\nCaption",
-        categoryEN: "Picture",
-        unpublishReason: "Image rights unclear"
-      });
-      const origCat = article.categoryEN;
-      article.categoryEN = "--unpublished--";
-      const result = renderer.renderArticle("EN", article);
-      // When unpublished, it renders as standard article (li) with unpublish reason
-      should(result).match(/Image rights unclear/);
-      should(result).match(/Caption/);
-      bddone();
-    });
-    it("should handle unpublished upcoming events article", function (bddone) {
-      const article = articleModule.create({
-        markdownDE: "Event scheduled for later",
-        categoryEN: "Upcoming Events",
-        unpublishReason: "Date not confirmed",
-        unpublishReference: "Issue #123"
-      });
-      article.categoryEN = "--unpublished--";
-      const result = renderer.renderArticle("DE", article);
-      should(result).match(/Date not confirmed/);
-      should(result).match(/Issue #123/);
-      bddone();
-    });
-  });
-
-  describe("hugoMarkdownArticle", function() {
-    let markdownRenderer;
-    before(function() {
-      markdownRenderer = BlogRenderer.createRenderer("HUGO");
+    after(function (bddone) {
+        nock.cleanAll();
+        bddone();
     });
 
-    it("should replace configured shortcut emojis in Hugo markdown", function (bddone) {
-      const article = articleModule.create({ markdownDE: "Test article with shortcut :-)" });
-      const result = markdownRenderer.renderArticle("DE", article);
-      should(result).containEql("😃");
-      should(result).not.containEql('{{< icon "😃" >}}');
-      bddone();
+    describe("htmlArticle", function () {
+        it("should generate a preview when no markdown is specified (no Edit Link)", function (bddone) {
+            const article = articleModule.create({ title: "Test Title" });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal('<li id="undefined_0">\nTest Title\n</li>\n');
+            bddone();
+        });
+        it("should generate a preview when no markdown2 is specified (no Edit Link)", function (bddone) {
+            const article = articleModule.create({ collection: "Test Collection" });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal('<li id="undefined_0">\nTest Collection\n</li>\n');
+            bddone();
+        });
+        it("should generate a preview when no markdown2 is specified (Edit Link)", function (bddone) {
+            const article = articleModule.create({ collection: "Test Collection" });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal('<li id="undefined_0">\nTest Collection\n</li>\n');
+            bddone();
+        });
+        it("should indent all leading asterisks in multiline article content", function (bddone) {
+            // Result is broken as "* " in the beginnin of an article is removed
+            // so double * are not allowed yet. They do not make sense imho TheFive
+            const article = articleModule.create({
+                markdownDE: "* line one\n* line two\n* line three",
+                id: 5,
+                blog: "TEST",
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal(
+                '<li id="test_5">\n<p>line one</p>\n<ul>\n<li>line two</li>\n<li>line three</li>\n</ul>\n</li>\n',
+            );
+            bddone();
+        });
+        it("should generate a preview when markdown is specified (Edit Link) (editor mode)", function (bddone) {
+            const renderer = BlogRenderer.createRenderer("HTML", null, { target: "editor" });
+            const article = articleModule.create({
+                markdownDE: "[Paul](https://test.link.de) tells something about [nothing](www.nothing.de).",
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal(
+                '<li id="undefined_0">\n<a href="https://test.link.de" target="_blank" rel="noopener">Paul</a> tells something about <a href="www.nothing.de" target="_blank" rel="noopener">nothing</a>.\n</li>\n',
+            );
+            bddone();
+        });
+        it("should generate a preview when markdown is specified (Edit Link) (production mode)", function (bddone) {
+            const renderer = BlogRenderer.createRenderer("HTML", null, { target: "production" });
+            const article = articleModule.create({
+                markdownDE: "[Paul](https://test.link.de) tells something about [nothing](www.nothing.de).",
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal(
+                '<li id="undefined_0">\n<a href="https://test.link.de" class="production">Paul</a> tells something about <a href="www.nothing.de" class="production">nothing</a>.\n</li>\n',
+            );
+            bddone();
+        });
+        it("should generate a preview when markdown is specified (Translate Link Required)", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "[Paul](https://test.link.de) tells something about [nothing](www.nothing.de).",
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal(
+                '<li id="undefined_0">\n<a href="https://test.link.de">Paul</a> tells something about <a href="www.nothing.de">nothing</a>.\n</li>\n',
+            );
+            bddone();
+        });
+        it("should generate a preview when markdown is specified (with Star)", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "* [Paul](https://test.link.de) tells something about [nothing](www.nothing.de).",
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal(
+                '<li id="undefined_0">\n<a href="https://test.link.de">Paul</a> tells something about <a href="www.nothing.de">nothing</a>.\n</li>\n',
+            );
+            bddone();
+        });
+        it("should generate a preview with a comment and no status", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "small markdown",
+                commentList: [{ text: "Hallo" }],
+                commentRead: { TheFive: 0 },
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal('<li id="undefined_0">\nsmall markdown\n</li>\n');
+            bddone();
+        });
+        it("should generate a preview with a comment and open status", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "small markdown",
+                commentList: [{ text: "Hallo" }],
+                commentStatus: "open",
+                commentRead: { TheFive: 0 },
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal('<li id="undefined_0">\nsmall markdown\n</li>\n');
+            bddone();
+        });
+        it("should generate a preview with a comment and open status checking Marktext", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "small markdown",
+                commentList: [{ text: "Hallo" }],
+                commentStatus: "open",
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal('<li id=\"undefined_0\">\nsmall markdown\n</li>\n');
+            bddone();
+        });
+        it("should generate a preview (no markdown) with a comment and open status", function (bddone) {
+            const article = articleModule.create({
+                collection: "small collection",
+                commentList: [{ text: "Hallo @EN" }],
+                commentStatus: "open",
+                commentRead: { TheFive: 0 },
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal('<li id="undefined_0">\nsmall collection\n</li>\n');
+            bddone();
+        });
+        it("should generate a preview (no markdown) with a comment and open status case insensitive test", function (bddone) {
+            const article = articleModule.create({
+                collection: "small collection",
+                commentList: [{ text: "Hallo @en" }],
+                commentStatus: "open",
+                commentRead: { PaulFromMars: 0 },
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal('<li id="undefined_0">\nsmall collection\n</li>\n');
+            bddone();
+        });
+        it("should generate a preview with a comment and open status and reference for all user", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "small markdown",
+                commentList: [{ text: "Hallo @all" }],
+                commentStatus: "open",
+                commentRead: { TheFive: 0 },
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal('<li id="undefined_0">\nsmall markdown\n</li>\n');
+            bddone();
+        });
+        it("should generate a preview with a comment and open status and reference for a specific user", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "small markdown",
+                commentList: [{ text: "Hallo @user" }],
+                commentStatus: "open",
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal('<li id="undefined_0">\nsmall markdown\n</li>\n');
+            bddone();
+        });
+        it("should generate a preview with a comment and open status and reference for a specific language", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "small markdown",
+                commentList: [{ text: "simpel text" }, { text: "Hallo @DE" }, { text: "dudeldü" }],
+                commentStatus: "open",
+                commentRead: { user: 0 },
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal('<li id="undefined_0">\nsmall markdown\n</li>\n');
+            bddone();
+        });
+        it("should generate a preview with a comment and solved status", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "small markdown",
+                commentList: [{ text: "solved" }],
+                commentStatus: "solved",
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal('<li id="undefined_0">\nsmall markdown\n</li>\n');
+            bddone();
+        });
+        it("should generate a preview Github Error #102 in german", function (bddone) {
+            const article = articleModule.create({
+                markdownDE:
+                    "Howto place an issue in OSMBC? \n1. open OSMBC, \n1. click Collect,\n1. choose a category from the pop up window\n1. write a Titel: example: Lidar,\n1. write at text or put a link\n1. click OK\n--- reday --- \n\nIf you like to write the news directly, do as follows:\n\n1. click Edit\n2. write your news in English (you can see it in \n3. click OK and ...\n... that's it.",
+                commentList: [{ text: "Hallo" }],
+                commentStatus: "solved",
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal(
+                '<li id="undefined_0">\n<p>Howto place an issue in OSMBC?</p>\n<ol>\n<li>open OSMBC,</li>\n<li>click Collect,</li>\n<li>choose a category from the pop up window</li>\n<li>write a Titel: example: Lidar,</li>\n<li>write at text or put a link</li>\n<li>click OK\n--- reday ---</li>\n</ol>\n<p>If you like to write the news directly, do as follows:</p>\n<ol>\n<li>click Edit</li>\n<li>write your news in English (you can see it in</li>\n<li>click OK and ...\n... that\'s it.</li>\n</ol>\n</li>\n',
+            );
+            bddone();
+        });
+        it("should generate a preview Github Error #102 in english", function (bddone) {
+            const article = articleModule.create({
+                markdownEN:
+                    "Howto place an issue in OSMBC? \n1. open OSMBC, \n1. click Collect,\n1. choose a category from the pop up window\n1. write a Titel: example: Lidar,\n1. write at text or put a link\n1. click OK\n--- reday --- \n\nIf you like to write the news directly, do as follows:\n1. click Edit\n2. write your news in English (you can see it in \n3. click OK and ...\n... that's it.",
+                commentList: [{ text: "Hallo" }],
+                commentStatus: "solved",
+            });
+            const result = renderer.renderArticle("EN", article);
+            should(result).equal(
+                '<li id="undefined_0">\n<p>Howto place an issue in OSMBC?</p>\n<ol>\n<li>open OSMBC,</li>\n<li>click Collect,</li>\n<li>choose a category from the pop up window</li>\n<li>write a Titel: example: Lidar,</li>\n<li>write at text or put a link</li>\n<li>click OK\n--- reday ---</li>\n</ol>\n<p>If you like to write the news directly, do as follows:</p>\n<ol>\n<li>click Edit</li>\n<li>write your news in English (you can see it in</li>\n<li>click OK and ...\n... that\'s it.</li>\n</ol>\n</li>\n',
+            );
+            bddone();
+        });
+        it("should generate a preview for a picture", function (bddone) {
+            const article = articleModule.create({
+                markdownEN:
+                    "![Alternative Text](https://osmbc.com/picture.jpg =300x200)\n\nSome caption text allowing superscript [^[1]^](#WN271_wetterabhängige_Karte)",
+                categoryEN: "Picture",
+                commentList: [{ text: "Hallo" }],
+                commentStatus: "solved",
+            });
+            const result = renderer.renderArticle("EN", article);
+            should(result).equal(
+                '<div style="width: 310px" class="wp-caption alignnone"> \n<p class="wp-caption-text"><img src="https://osmbc.com/picture.jpg" alt="Alternative Text" width="300" height="200"></p>\n<p class="wp-caption-text">Some caption text allowing superscript <a href="#WN271_wetterabh%C3%A4ngige_Karte"><sup>[1]</sup></a></p>\n</div>\n',
+            );
+            bddone();
+        });
+        it("should generate a preview for a translation", function (bddone) {
+            const article = articleModule.create({
+                markdownEN: "We will tell you something about maps.",
+                markdownDE: "Wir erzählen euch was über Karten.",
+                categoryEN: "Maps",
+                commentList: [{ text: "Hallo" }],
+                commentStatus: "solved",
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal('<li id=\"undefined_0\">\nWir erzählen euch was über Karten.\n</li>\n');
+            bddone();
+        });
+        it("should generate an article for Upcoming Events", function (bddone) {
+            const article = articleModule.create({
+                markdownEN: "This is a table",
+                markdownDE: "Eine Tabelle",
+                categoryEN: "Upcoming Events",
+            });
+            const result = renderer.renderArticle("DE", article);
+            should(result).equal(
+                '<p>Eine Tabelle\n</p>\n<p>Hinweis:<br />Wer seinen Termin hier in der Liste sehen möchte, <a href=\"https://wiki.openstreetmap.org/wiki/Template:Calendar\">trage</a> ihn in den <a href=\"https://wiki.openstreetmap.org/wiki/Current_events\">Kalender</a> ein. Nur Termine, die dort stehen, werden in die Wochennotiz übernommen.</p>\n',
+            );
+            bddone();
+        });
+        it("should work with Emojies", function (bddone) {
+            const article = articleModule.create({
+                markdownEN: "Greetings from [:germany:](https://en.wikipedia.org/wiki/Germany) :-)",
+                categoryEN: "Maps",
+            });
+            const result = renderer.renderArticle("EN", article);
+            should(result).equal(
+                '<li id="undefined_0">\nGreetings from <a href="https://en.wikipedia.org/wiki/Germany"><img src=\"/localMediaFOlder2015/de-black.svg\" /></a> 😃\n</li>\n',
+            );
+            bddone();
+        });
+        it("should handle unpublished picture article with reason", function (bddone) {
+            const article = articleModule.create({
+                markdownEN: "![Alt Text](https://example.com/pic.jpg =300x200)\n\nCaption",
+                categoryEN: "Picture",
+                unpublishReason: "Image rights unclear",
+            });
+            const origCat = article.categoryEN;
+            article.categoryEN = "--unpublished--";
+            const result = renderer.renderArticle("EN", article);
+            // When unpublished, it renders as standard article (li) with unpublish reason
+            should(result).match(/Image rights unclear/);
+            should(result).match(/Caption/);
+            bddone();
+        });
+        it("should handle unpublished upcoming events article", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "Event scheduled for later",
+                categoryEN: "Upcoming Events",
+                unpublishReason: "Date not confirmed",
+                unpublishReference: "Issue #123",
+            });
+            article.categoryEN = "--unpublished--";
+            const result = renderer.renderArticle("DE", article);
+            should(result).match(/Date not confirmed/);
+            should(result).match(/Issue #123/);
+            bddone();
+        });
     });
 
-    it("should replace configured flag emojis in Hugo markdown", function (bddone) {
-      const article = articleModule.create({ markdownDE: "Test article with flag :germany:" });
-      const result = markdownRenderer.renderArticle("DE", article);
-      should(result).containEql("{{< icon ");
-      should(result).containEql("de-black.svg");
-      bddone();
-    });
+    describe("hugoMarkdownArticle", function () {
+        let markdownRenderer;
+        before(function () {
+            markdownRenderer = BlogRenderer.createRenderer("HUGO");
+        });
 
-    it("should apply chained conversion when shortcut expands to named emoji", function (bddone) {
-      const originalGetConfig = configModule.getConfig;
-      configModule.getConfig = function(name) {
-        if (name === "languageflags") {
-          return {
-            shortcut: {
-              chain: ">>>"
-            },
-            emoji: {
-              chain: ":germany:",
-              germany: "/localMediaFOlder2015/de-black.svg"
+        it("should replace configured shortcut emojis in Hugo markdown", function (bddone) {
+            const article = articleModule.create({ markdownDE: "Test article with shortcut :-)" });
+            const result = markdownRenderer.renderArticle("DE", article);
+            should(result).containEql("😃");
+            should(result).not.containEql('{{< icon "😃" >}}');
+            bddone();
+        });
+
+        it("should replace configured flag emojis in Hugo markdown", function (bddone) {
+            const article = articleModule.create({ markdownDE: "Test article with flag :germany:" });
+            const result = markdownRenderer.renderArticle("DE", article);
+            should(result).containEql("{{< icon ");
+            should(result).containEql("de-black.svg");
+            bddone();
+        });
+
+        it("should apply chained conversion when shortcut expands to named emoji", function (bddone) {
+            const originalGetConfig = configModule.getConfig;
+            configModule.getConfig = function (name) {
+                if (name === "languageflags") {
+                    return {
+                        shortcut: {
+                            chain: ">>>",
+                        },
+                        emoji: {
+                            chain: ":germany:",
+                            germany: "/localMediaFOlder2015/de-black.svg",
+                        },
+                    };
+                }
+                return originalGetConfig(name);
+            };
+
+            try {
+                const article = articleModule.create({ markdownDE: "Test chain >>> done" });
+                const result = markdownRenderer.renderArticle("DE", article);
+                should(result).containEql('{{< icon "/localMediaFOlder2015/de-black.svg" >}}');
+                should(result).not.containEql(":germany:");
+                bddone();
+            } finally {
+                configModule.getConfig = originalGetConfig;
             }
-          };
-        }
-        return originalGetConfig(name);
-      };
+        });
 
-      try {
-        const article = articleModule.create({ markdownDE: "Test chain >>> done" });
-        const result = markdownRenderer.renderArticle("DE", article);
-        should(result).containEql('{{< icon "/localMediaFOlder2015/de-black.svg" >}}');
-        should(result).not.containEql(":germany:");
-        bddone();
-      } finally {
-        configModule.getConfig = originalGetConfig;
-      }
-    });
-
-    it("should generate markdown for picture article", function (bddone) {
-      const article = articleModule.create({
-        markdownEN: "![Alt Text](https://example.com/img.jpg =300x200)\n\nCaption text",
-        categoryEN: "Picture"
-      });
-      const result = markdownRenderer.renderArticle("EN", article);
-      should(result).equal("");
-      bddone();
-    });
-
-    it("should replace generic ^text^ superscript markup with a Hugo sup shortcode", function (bddone) {
-      const article = articleModule.create({ markdownEN: "Starting 1^er^ May and the 12^th^ of June" });
-      const result = markdownRenderer.renderArticle("EN", article);
-      should(result).containEql('1{{< sup "er" >}} May');
-      should(result).containEql('12{{< sup "th" >}} of June');
-      bddone();
-    });
-
-    it("should not merge two separate ^text^ spans across their inner carets", function (bddone) {
-      const article = articleModule.create({ markdownEN: "See ^a^ and then ^b^ too" });
-      const result = markdownRenderer.renderArticle("EN", article);
-      should(result).containEql('{{< sup "a" >}}');
-      should(result).containEql('{{< sup "b" >}}');
-      should(result).not.containEql('sup "a^ and then ^b"');
-      bddone();
-    });
-
-    it("should leave ^text with a space^ untouched, matching markdown-it-sup's own rule", function (bddone) {
-      const article = articleModule.create({ markdownEN: "This is ^not superscript^ here" });
-      const result = markdownRenderer.renderArticle("EN", article);
-      should(result).containEql("^not superscript^");
-      should(result).not.containEql("{{< sup");
-      bddone();
-    });
-
-    it("should fold uppercase to its lowercase Unicode superscript glyph in _replaceSuperscriptUnicode (front matter can't use shortcodes)", function (bddone) {
-      // Real content example: Italian "il^XII^ e il^XIII^ secolo" (WN801)
-      const result = markdownRenderer._replaceSuperscriptUnicode("il^XII^ secolo");
-      should(result).equal("ilˣⁱⁱ secolo");
-      bddone();
-    });
-
-    it("should generate markdown for upcoming events", function (bddone) {
-      const article = articleModule.create({
-        markdownDE: "Event details in markdown",
-        categoryEN: "Upcoming Events"
-      });
-      const result = markdownRenderer.renderArticle("DE", article);
-      // Upcoming Events in Markdown don't get the "* " prefix like Standard
-      should(result).equal("Event details in markdown");
-      bddone();
-    });
-
-    it("should indent leading asterisk in article content", function (bddone) {
-      const article = articleModule.create({
-        markdownEN: "* Already has asterisk",
-        id: 3,
-        blog: "BLOG"
-      });
-      const result = markdownRenderer.renderArticle("EN", article);
-      should(result).equal('* {{< anchor "blog_3" >}} Already has asterisk');
-      bddone();
-    });
-
-    it("should indent all leading asterisks in multiline article content", function (bddone) {
-      // result is broken as "* " in the beginnin of an article is removed
-      // so double * are not allowed yet. They do not make sense imho TheFive
-      const article = articleModule.create({
-        markdownDE: "* line one\n* line two\n* line three",
-        id: 5,
-        blog: "TEST"
-      });
-      const result = markdownRenderer.renderArticle("DE", article);
-      should(result).equal('* {{< anchor "test_5" >}} line one\n  * line two\n  * line three');
-      bddone();
-    });
-
-    it("should only indent asterisks at start of line, not mid-line", function (bddone) {
-      const article = articleModule.create({
-        markdownDE: "normal line\n* sub item\nnormal again",
-        id: 6,
-        blog: "TEST"
-      });
-      const result = markdownRenderer.renderArticle("DE", article);
-      should(result).equal('* {{< anchor "test_6" >}} normal line\n  * sub item\nnormal again');
-      bddone();
-    });
-
-    it("should fallback to title for markdown article with no markdown", function (bddone) {
-      const article = articleModule.create({ collection: "Collection Title" ,id: 4, blog: "BLOG" });
-      const result = markdownRenderer.renderArticle("DE", article);
-      should(result).equal('* {{< anchor "blog_4" >}} Collection Title\n');
-      bddone();
-    });
-
-    it("should generate markdown for unpublished article (no metadata added)", function (bddone) {
-      const article = articleModule.create({
-        markdownDE: "Content",
-        categoryEN: "--unpublished--",
-        unpublishReason: "Test reason"
-      });
-      const result = markdownRenderer.renderArticle("DE", article);
-      // Unpublished renders via renderArticleStandard (not recognized as special category)
-      // which adds "* ", then renderArticleUnpublished returns it unchanged
-      should(result).equal('* {{< anchor "undefined_0" >}} Content');
-      bddone();
-    });
-  });
-
-  describe("hugoMarkdownFrontMatterAliases", function() {
-    it("should emit both the prefix-less and /en/ weeklyosm.eu archive alias for English", function () {
-      const renderer = BlogRenderer.createRenderer("HUGO", { name: "WN219" });
-      should(renderer._archiveAliases("EN")).eql(["/archives/214", "/en/archives/214"]);
-    });
-
-    it("should prefix a non-default language with its weeklyosm.eu URL segment", function () {
-      const renderer = BlogRenderer.createRenderer("HUGO", { name: "WN219" });
-      should(renderer._archiveAliases("DE")).eql(["/de/archives/214"]);
-    });
-
-    it("should alias Brazilian Portuguese under both /br/ (current) and /pb/ (historical) segments", function () {
-      const renderer = BlogRenderer.createRenderer("HUGO", { name: "WN219" });
-      should(renderer._archiveAliases("BR")).eql(["/br/archives/214", "/pb/archives/214"]);
-    });
-
-    it("should return no aliases for an issue before the weeklyosm.eu era", function () {
-      const renderer = BlogRenderer.createRenderer("HUGO", { name: "WN100" });
-      should(renderer._archiveAliases("EN")).eql([]);
-    });
-
-    it("should return no aliases for a non-WN blog", function () {
-      const renderer = BlogRenderer.createRenderer("HUGO", { name: "YiR2016" });
-      should(renderer._archiveAliases("EN")).eql([]);
-    });
-
-    it("should render the aliases line into the TOML front matter", function () {
-      const renderer = BlogRenderer.createRenderer("HUGO", { name: "WN219", endDate: "2014-10-07" });
-      should(renderer._generateFrontText("DE")).containEql("aliases = ['/de/archives/214']");
-    });
-
-    it("should not render an aliases line for an issue that is not mapped", function () {
-      const renderer = BlogRenderer.createRenderer("HUGO", { name: "WN901", endDate: "2015-02-05" });
-      should(renderer._generateFrontText("DE")).not.containEql("aliases =");
-    });
-  });
-
-  describe("markdownArticle", function() {
-    let markdownRenderer;
-    before(function() {
-      markdownRenderer = BlogRenderer.createRenderer("MARKDOWN");
-    });
-
-    it("should generate markdown for standard article", function (bddone) {
-      const article = articleModule.create({ markdownDE: "Test article with content" });
-      const result = markdownRenderer.renderArticle("DE", article);
-      should(result).equal("* Test article with content");
-      bddone();
-    });
-
-    it("should generate markdown for picture article", function (bddone) {
-      const article = articleModule.create({
-        markdownEN: "![Alt Text](https://example.com/img.jpg =300x200)\n\nCaption text",
-        categoryEN: "Picture"
-      });
-      const result = markdownRenderer.renderArticle("EN", article);
-      should(result).equal("![Alt Text](https://example.com/img.jpg =300x200)\n\nCaption text");
-      bddone();
-    });
-
-    it("should generate markdown for upcoming events", function (bddone) {
-      const article = articleModule.create({
-        markdownDE: "Event details in markdown",
-        categoryEN: "Upcoming Events"
-      });
-      const result = markdownRenderer.renderArticle("DE", article);
-      should(result).equal("Event details in markdown");
-      bddone();
-    });
-
-    it("should indent leading asterisk in article content", function (bddone) {
-      const article = articleModule.create({
-        markdownEN: "* Already has asterisk",
-        id: 3,
-        blog: "BLOG"
-      });
-      const result = markdownRenderer.renderArticle("EN", article);
-      should(result).equal("* Already has asterisk");
-      bddone();
-    });
-
-    it("should indent all leading asterisks in multiline article content", function (bddone) {
-      // result is broken as "* " in the beginnin of an article is removed
-      // so double * are not allowed yet. They do not make sense imho TheFive
-      const article = articleModule.create({
-        markdownDE: "* line one\n* line two\n* line three",
-        id: 5,
-        blog: "TEST"
-      });
-      const result = markdownRenderer.renderArticle("DE", article);
-      should(result).equal("* line one\n  * line two\n  * line three");
-      bddone();
-    });
-
-    it("should only indent asterisks at start of line, not mid-line", function (bddone) {
-      const article = articleModule.create({
-        markdownDE: "normal line\n* sub item\nnormal again",
-        id: 6,
-        blog: "TEST"
-      });
-      const result = markdownRenderer.renderArticle("DE", article);
-      should(result).equal("* normal line\n  * sub item\nnormal again");
-      bddone();
-    });
-
-    it("should fallback to title for markdown article with no markdown", function (bddone) {
-      const article = articleModule.create({ collection: "Collection Title" ,id: 4, blog: "BLOG" });
-      const result = markdownRenderer.renderArticle("DE", article);
-      should(result).equal("* Collection Title\n");
-      bddone();
-    });
-
-    it("should generate markdown for unpublished article (no metadata added)", function (bddone) {
-      const article = articleModule.create({
-        markdownDE: "Content",
-        categoryEN: "--unpublished--",
-        unpublishReason: "Test reason"
-      });
-      const result = markdownRenderer.renderArticle("DE", article);
-      should(result).equal("* Content");
-      bddone();
-    });
-  });
-
-  describe("renderBlog", function() {
-    beforeEach(function (bddone) {
-      testutil.clearDB(bddone);
-    });
-    function doATest(filename) {
-      it("should handle testfile " + filename, function (bddone) {
-        const file =  path.resolve(config.getDirName(), "test/data", filename);
-        const data =  JSON.parse(fs.readFileSync(file));
-
-        let blog;
-        let html;
-
-        async.series([
-          function(done) {
-            testutil.importData(data, done);
-          },
-          function(done) {
-            blogModule.findOne({ name: data.testBlogName }, function(err, result) {
-              should.not.exist(err);
-              blog = result;
-              should.exist(blog);
-              done();
+        it("should generate markdown for picture article", function (bddone) {
+            const article = articleModule.create({
+                markdownEN: "![Alt Text](https://example.com/img.jpg =300x200)\n\nCaption text",
+                categoryEN: "Picture",
             });
-          },
-          function(done) {
-            let renderer = BlogRenderer.createRenderer("HTML", blog);
-            if (data.asMarkdown) renderer = BlogRenderer.createRenderer("HUGO", blog);
+            const result = markdownRenderer.renderArticle("EN", article);
+            should(result).equal("");
+            bddone();
+        });
 
-            blog.getPreviewData({ lang: data.lang, createTeam: true, disableNotranslation: true }, function(err, result) {
-              should.not.exist(err);
+        it("should replace generic ^text^ superscript markup with a Hugo sup shortcode", function (bddone) {
+            const article = articleModule.create({ markdownEN: "Starting 1^er^ May and the 12^th^ of June" });
+            const result = markdownRenderer.renderArticle("EN", article);
+            should(result).containEql('1{{< sup "er" >}} May');
+            should(result).containEql('12{{< sup "th" >}} of June');
+            bddone();
+        });
 
-              html = renderer.renderBlog(data.lang, result);
-              done();
+        it("should not merge two separate ^text^ spans across their inner carets", function (bddone) {
+            const article = articleModule.create({ markdownEN: "See ^a^ and then ^b^ too" });
+            const result = markdownRenderer.renderArticle("EN", article);
+            should(result).containEql('{{< sup "a" >}}');
+            should(result).containEql('{{< sup "b" >}}');
+            should(result).not.containEql('sup "a^ and then ^b"');
+            bddone();
+        });
+
+        it("should leave ^text with a space^ untouched, matching markdown-it-sup's own rule", function (bddone) {
+            const article = articleModule.create({ markdownEN: "This is ^not superscript^ here" });
+            const result = markdownRenderer.renderArticle("EN", article);
+            should(result).containEql("^not superscript^");
+            should(result).not.containEql("{{< sup");
+            bddone();
+        });
+
+        it("should fold uppercase to its lowercase Unicode superscript glyph in _replaceSuperscriptUnicode (front matter can't use shortcodes)", function (bddone) {
+            // Real content example: Italian "il^XII^ e il^XIII^ secolo" (WN801)
+            const result = markdownRenderer._replaceSuperscriptUnicode("il^XII^ secolo");
+            should(result).equal("ilˣⁱⁱ secolo");
+            bddone();
+        });
+
+        it("should generate markdown for upcoming events", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "Event details in markdown",
+                categoryEN: "Upcoming Events",
             });
-          }
+            const result = markdownRenderer.renderArticle("DE", article);
+            // Upcoming Events in Markdown don't get the "* " prefix like Standard
+            should(result).equal("Event details in markdown");
+            bddone();
+        });
 
-        ],
-        function (err) {
-          should.not.exist(err);
+        it("should indent leading asterisk in article content", function (bddone) {
+            const article = articleModule.create({
+                markdownEN: "* Already has asterisk",
+                id: 3,
+                blog: "BLOG",
+            });
+            const result = markdownRenderer.renderArticle("EN", article);
+            should(result).equal('* {{< anchor "blog_3" >}} Already has asterisk');
+            bddone();
+        });
 
-          let htmlResult = data.testBlogResultHtml;
-          let htmlFile = "";
-          let markdown = false;
+        it("should indent all leading asterisks in multiline article content", function (bddone) {
+            // result is broken as "* " in the beginnin of an article is removed
+            // so double * are not allowed yet. They do not make sense imho TheFive
+            const article = articleModule.create({
+                markdownDE: "* line one\n* line two\n* line three",
+                id: 5,
+                blog: "TEST",
+            });
+            const result = markdownRenderer.renderArticle("DE", article);
+            should(result).equal('* {{< anchor "test_5" >}} line one\n  * line two\n  * line three');
+            bddone();
+        });
 
-          try {
-            // try to read file content,
-            // if it fails, use the already defined value
-            const file =  path.resolve(config.getDirName(), "test/data", htmlResult);
-            htmlFile =htmlResult;
+        it("should only indent asterisks at start of line, not mid-line", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "normal line\n* sub item\nnormal again",
+                id: 6,
+                blog: "TEST",
+            });
+            const result = markdownRenderer.renderArticle("DE", article);
+            should(result).equal('* {{< anchor "test_6" >}} normal line\n  * sub item\nnormal again');
+            bddone();
+        });
 
-            htmlResult = fs.readFileSync(file, "utf-8");
-            if (file.indexOf(".md") >= 0) markdown = true;
-          } catch (err) { /* ignore the error */ }
+        it("should fallback to title for markdown article with no markdown", function (bddone) {
+            const article = articleModule.create({ collection: "Collection Title", id: 4, blog: "BLOG" });
+            const result = markdownRenderer.renderArticle("DE", article);
+            should(result).equal('* {{< anchor "blog_4" >}} Collection Title\n');
+            bddone();
+        });
 
-          if (markdown) {
-            testutil.expectTextFile(html,"data",htmlFile);
-          } else {
-            should(html).eql(htmlResult);
-          }
+        it("should generate markdown for unpublished article (no metadata added)", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "Content",
+                categoryEN: "--unpublished--",
+                unpublishReason: "Test reason",
+            });
+            const result = markdownRenderer.renderArticle("DE", article);
+            // Unpublished renders via renderArticleStandard (not recognized as special category)
+            // which adds "* ", then renderArticleUnpublished returns it unchanged
+            should(result).equal('* {{< anchor "undefined_0" >}} Content');
+            bddone();
+        });
+    });
 
-          bddone();
+    describe("hugoMarkdownFrontMatterAliases", function () {
+        it("should prefix a non-default language with its weeklyosm.eu URL segment", function () {
+            const renderer = BlogRenderer.createRenderer("HUGO", { name: "WN219" });
+            should(renderer._archiveAliases()).eql(["/archives/214"]);
+        });
+
+        it("should return no aliases for an issue before the weeklyosm.eu era", function () {
+            const renderer = BlogRenderer.createRenderer("HUGO", { name: "WN100" });
+            should(renderer._archiveAliases()).eql([]);
+        });
+
+        it("should return no aliases for a non-WN blog", function () {
+            const renderer = BlogRenderer.createRenderer("HUGO", { name: "YiR2016" });
+            should(renderer._archiveAliases()).eql([]);
+        });
+
+        it("should render the aliases line into the TOML front matter", function () {
+            const renderer = BlogRenderer.createRenderer("HUGO", { name: "WN219", endDate: "2014-10-07" });
+            should(renderer._generateFrontText()).containEql("aliases = ['/archives/214']");
+        });
+
+        it("should not render an aliases line for an issue that is not mapped", function () {
+            const renderer = BlogRenderer.createRenderer("HUGO", { name: "WN901", endDate: "2015-02-05" });
+            should(renderer._generateFrontText()).not.containEql("aliases =");
+        });
+    });
+
+    describe("markdownArticle", function () {
+        let markdownRenderer;
+        before(function () {
+            markdownRenderer = BlogRenderer.createRenderer("MARKDOWN");
+        });
+
+        it("should generate markdown for standard article", function (bddone) {
+            const article = articleModule.create({ markdownDE: "Test article with content" });
+            const result = markdownRenderer.renderArticle("DE", article);
+            should(result).equal("* Test article with content");
+            bddone();
+        });
+
+        it("should generate markdown for picture article", function (bddone) {
+            const article = articleModule.create({
+                markdownEN: "![Alt Text](https://example.com/img.jpg =300x200)\n\nCaption text",
+                categoryEN: "Picture",
+            });
+            const result = markdownRenderer.renderArticle("EN", article);
+            should(result).equal("![Alt Text](https://example.com/img.jpg =300x200)\n\nCaption text");
+            bddone();
+        });
+
+        it("should generate markdown for upcoming events", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "Event details in markdown",
+                categoryEN: "Upcoming Events",
+            });
+            const result = markdownRenderer.renderArticle("DE", article);
+            should(result).equal("Event details in markdown");
+            bddone();
+        });
+
+        it("should indent leading asterisk in article content", function (bddone) {
+            const article = articleModule.create({
+                markdownEN: "* Already has asterisk",
+                id: 3,
+                blog: "BLOG",
+            });
+            const result = markdownRenderer.renderArticle("EN", article);
+            should(result).equal("* Already has asterisk");
+            bddone();
+        });
+
+        it("should indent all leading asterisks in multiline article content", function (bddone) {
+            // result is broken as "* " in the beginnin of an article is removed
+            // so double * are not allowed yet. They do not make sense imho TheFive
+            const article = articleModule.create({
+                markdownDE: "* line one\n* line two\n* line three",
+                id: 5,
+                blog: "TEST",
+            });
+            const result = markdownRenderer.renderArticle("DE", article);
+            should(result).equal("* line one\n  * line two\n  * line three");
+            bddone();
+        });
+
+        it("should only indent asterisks at start of line, not mid-line", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "normal line\n* sub item\nnormal again",
+                id: 6,
+                blog: "TEST",
+            });
+            const result = markdownRenderer.renderArticle("DE", article);
+            should(result).equal("* normal line\n  * sub item\nnormal again");
+            bddone();
+        });
+
+        it("should fallback to title for markdown article with no markdown", function (bddone) {
+            const article = articleModule.create({ collection: "Collection Title", id: 4, blog: "BLOG" });
+            const result = markdownRenderer.renderArticle("DE", article);
+            should(result).equal("* Collection Title\n");
+            bddone();
+        });
+
+        it("should generate markdown for unpublished article (no metadata added)", function (bddone) {
+            const article = articleModule.create({
+                markdownDE: "Content",
+                categoryEN: "--unpublished--",
+                unpublishReason: "Test reason",
+            });
+            const result = markdownRenderer.renderArticle("DE", article);
+            should(result).equal("* Content");
+            bddone();
+        });
+    });
+
+    describe("renderBlog", function () {
+        beforeEach(function (bddone) {
+            testutil.clearDB(bddone);
+        });
+        function doATest(filename) {
+            it("should handle testfile " + filename, function (bddone) {
+                const file = path.resolve(config.getDirName(), "test/data", filename);
+                const data = JSON.parse(fs.readFileSync(file));
+
+                let blog;
+                let html;
+
+                async.series(
+                    [
+                        function (done) {
+                            testutil.importData(data, done);
+                        },
+                        function (done) {
+                            blogModule.findOne({ name: data.testBlogName }, function (err, result) {
+                                should.not.exist(err);
+                                blog = result;
+                                should.exist(blog);
+                                done();
+                            });
+                        },
+                        function (done) {
+                            let renderer = BlogRenderer.createRenderer("HTML", blog);
+                            if (data.asMarkdown) renderer = BlogRenderer.createRenderer("HUGO", blog);
+
+                            blog.getPreviewData(
+                                { lang: data.lang, createTeam: true, disableNotranslation: true },
+                                function (err, result) {
+                                    should.not.exist(err);
+
+                                    html = renderer.renderBlog(data.lang, result);
+                                    done();
+                                },
+                            );
+                        },
+                    ],
+                    function (err) {
+                        should.not.exist(err);
+
+                        let htmlResult = data.testBlogResultHtml;
+                        let htmlFile = "";
+                        let markdown = false;
+
+                        try {
+                            // try to read file content,
+                            // if it fails, use the already defined value
+                            const file = path.resolve(config.getDirName(), "test/data", htmlResult);
+                            htmlFile = htmlResult;
+
+                            htmlResult = fs.readFileSync(file, "utf-8");
+                            if (file.indexOf(".md") >= 0) markdown = true;
+                        } catch (err) {
+                            /* ignore the error */
+                        }
+
+                        if (markdown) {
+                            testutil.expectTextFile(html, "data", htmlFile);
+                        } else {
+                            should(html).eql(htmlResult);
+                        }
+
+                        bddone();
+                    },
+                );
+            });
         }
-        );
-      });
-    }
-    testutil.generateTests("test/data", /^render.blog.renderBlog.+json/, doATest);
+        testutil.generateTests("test/data", /^render.blog.renderBlog.+json/, doATest);
 
-    it("should handle fixture render.blog.renderBlog.7.json with Hugo emoji replacements", function(bddone) {
-      const file = path.resolve(config.getDirName(), "test/data", "render.blog.renderBlog.7.json");
-      const data = JSON.parse(fs.readFileSync(file));
+        it("should handle fixture render.blog.renderBlog.7.json with Hugo emoji replacements", function (bddone) {
+            const file = path.resolve(config.getDirName(), "test/data", "render.blog.renderBlog.7.json");
+            const data = JSON.parse(fs.readFileSync(file));
 
-      let blog;
-      let html;
+            let blog;
+            let html;
 
-      async.series([
-        function(done) {
-          testutil.importData(data, done);
-        },
-        function(done) {
-          blogModule.findOne({ name: data.testBlogName }, function(err, result) {
-            should.not.exist(err);
-            blog = result;
-            should.exist(blog);
-            done();
-          });
-        },
-        function(done) {
-          const renderer = BlogRenderer.createRenderer("HUGO", blog);
-          blog.getPreviewData({ lang: data.lang, createTeam: true, disableNotranslation: true }, function(err, result) {
-            should.not.exist(err);
-            html = renderer.renderBlog(data.lang, result);
-            done();
-          });
+            async.series(
+                [
+                    function (done) {
+                        testutil.importData(data, done);
+                    },
+                    function (done) {
+                        blogModule.findOne({ name: data.testBlogName }, function (err, result) {
+                            should.not.exist(err);
+                            blog = result;
+                            should.exist(blog);
+                            done();
+                        });
+                    },
+                    function (done) {
+                        const renderer = BlogRenderer.createRenderer("HUGO", blog);
+                        blog.getPreviewData(
+                            { lang: data.lang, createTeam: true, disableNotranslation: true },
+                            function (err, result) {
+                                should.not.exist(err);
+                                html = renderer.renderBlog(data.lang, result);
+                                done();
+                            },
+                        );
+                    },
+                ],
+                function (err) {
+                    should.not.exist(err);
+                    testutil.expectTextFile(html, "data", "render.blog.preview.7.md");
+                    bddone();
+                },
+            );
+        });
+    });
+
+    describe("renderBlog warning integration", function () {
+        function createBlog(closed = true) {
+            return {
+                name: "WN999",
+                startDate: new Date("2024-01-01"),
+                endDate: new Date("2024-01-07"),
+                closeDE: closed,
+                getCategories() {
+                    return [{ EN: "News", DE: "News" }];
+                },
+            };
         }
-      ], function(err) {
-        should.not.exist(err);
-        testutil.expectTextFile(html, "data", "render.blog.preview.7.md");
-        bddone();
-      });
-    });
-  });
 
-  describe("renderBlog warning integration", function() {
-    function createBlog(closed = true) {
-      return {
-        name: "WN999",
-        startDate: new Date("2024-01-01"),
-        endDate: new Date("2024-01-07"),
-        closeDE: closed,
-        getCategories() {
-          return [{ EN: "News", DE: "News" }];
-        }
-      };
-    }
+        it("should include empty-article warning via renderBlog when articleData flag is set", function () {
+            const htmlRenderer = BlogRenderer.createRenderer("HTML", createBlog(true));
+            const article = articleModule.create({
+                id: 1,
+                blog: "WN999",
+                categoryEN: "News",
+                title: "Article without DE markdown",
+                markdownEN: "Only EN text",
+            });
 
-    it("should include empty-article warning via renderBlog when articleData flag is set", function() {
-      const htmlRenderer = BlogRenderer.createRenderer("HTML", createBlog(true));
-      const article = articleModule.create({
-        id: 1,
-        blog: "WN999",
-        categoryEN: "News",
-        title: "Article without DE markdown",
-        markdownEN: "Only EN text"
-      });
+            const articleData = {
+                articles: { News: [article] },
+                teamString: "",
+                containsEmptyArticlesWarning: true,
+            };
 
-      const articleData = {
-        articles: { News: [article] },
-        teamString: "",
-        containsEmptyArticlesWarning: true
-      };
+            const result = htmlRenderer.renderBlog("DE", articleData);
+            should(result).containEql("Warning: This export contains empty Articles");
+            should(result).containEql("Article without DE markdown");
+        });
 
-      const result = htmlRenderer.renderBlog("DE", articleData);
-      should(result).containEql("Warning: This export contains empty Articles");
-      should(result).containEql("Article without DE markdown");
-    });
+        it("should not include empty-article warning via renderBlog when flag is false", function () {
+            const htmlRenderer = BlogRenderer.createRenderer("HTML", createBlog(true));
+            const article = articleModule.create({
+                id: 2,
+                blog: "WN999",
+                categoryEN: "News",
+                markdownDE: "Vorhandener deutscher Text",
+            });
 
-    it("should not include empty-article warning via renderBlog when flag is false", function() {
-      const htmlRenderer = BlogRenderer.createRenderer("HTML", createBlog(true));
-      const article = articleModule.create({
-        id: 2,
-        blog: "WN999",
-        categoryEN: "News",
-        markdownDE: "Vorhandener deutscher Text"
-      });
+            const articleData = {
+                articles: { News: [article] },
+                teamString: "",
+                containsEmptyArticlesWarning: false,
+            };
 
-      const articleData = {
-        articles: { News: [article] },
-        teamString: "",
-        containsEmptyArticlesWarning: false
-      };
+            const result = htmlRenderer.renderBlog("DE", articleData);
+            should(result).not.containEql("Warning: This export contains empty Articles");
+        });
 
-      const result = htmlRenderer.renderBlog("DE", articleData);
-      should(result).not.containEql("Warning: This export contains empty Articles");
+        it("should return only front text for not-closed blog when onlyClosed is true", function () {
+            const htmlRenderer = BlogRenderer.createRenderer("HTML", createBlog(false));
+            const articleData = {
+                articles: { News: [] },
+                teamString: "",
+                containsEmptyArticlesWarning: true,
+            };
+
+            const result = htmlRenderer.renderBlog("DE", articleData, true);
+            should(result).equal('<meta charset="utf-8"/>\n');
+        });
     });
 
-    it("should return only front text for not-closed blog when onlyClosed is true", function() {
-      const htmlRenderer = BlogRenderer.createRenderer("HTML", createBlog(false));
-      const articleData = {
-        articles: { News: [] },
-        teamString: "",
-        containsEmptyArticlesWarning: true
-      };
+    describe("articleTitle method integration", function () {
+        let htmlRenderer;
+        let markdownRenderer;
 
-      const result = htmlRenderer.renderBlog("DE", articleData, true);
-      should(result).equal("<meta charset=\"utf-8\"/>\n");
-    });
-  });
+        before(async function () {
+            await configModule.initialise();
+            htmlRenderer = BlogRenderer.createRenderer("HTML");
+            markdownRenderer = BlogRenderer.createRenderer("MARKDOWN");
+        });
 
-  describe("articleTitle method integration", function() {
-    let htmlRenderer;
-    let markdownRenderer;
+        it("should render HTML article title from collection when no markdown exists", function () {
+            const article = articleModule.create({
+                collection: "Test Article via Collection",
+                id: 1,
+                blog: "TEST",
+            });
+            const result = htmlRenderer.articleTitle("DE", article);
+            should(result).containEql("Test Article via Collection");
+            should(result).match(/<li>/);
+            should(result).match(/<\/li>/);
+        });
 
-    before(async function() {
-      await configModule.initialise();
-      htmlRenderer = BlogRenderer.createRenderer("HTML");
-      markdownRenderer = BlogRenderer.createRenderer("MARKDOWN");
-    });
+        it("should render Markdown article title correctly", function () {
+            const article = articleModule.create({
+                title: "Markdown Title",
+                id: 2,
+                blog: "TEST",
+            });
+            const result = markdownRenderer.articleTitle("EN", article);
+            should(result).match(/^\* /);
+            should(result).containEql("Markdown Title");
+        });
 
-    it("should render HTML article title from collection when no markdown exists", function() {
-      const article = articleModule.create({
-        collection: "Test Article via Collection",
-        id: 1,
-        blog: "TEST"
-      });
-      const result = htmlRenderer.articleTitle("DE", article);
-      should(result).containEql("Test Article via Collection");
-      should(result).match(/<li>/);
-      should(result).match(/<\/li>/);
-    });
+        it("should handle unpublished article with reason in articleTitle", function () {
+            const article = articleModule.create({
+                title: "Unpublished Article",
+                categoryEN: "--unpublished--",
+                unpublishReason: "Not ready yet",
+                unpublishReference: "PR #123",
+            });
+            const result = htmlRenderer.articleTitle("EN", article);
+            should(result).containEql("Unpublished Article");
+            should(result).containEql("Not ready yet");
+            should(result).containEql("PR #123");
+            should(result).match(/<br>/);
+        });
 
-    it("should render Markdown article title correctly", function() {
-      const article = articleModule.create({
-        title: "Markdown Title",
-        id: 2,
-        blog: "TEST"
-      });
-      const result = markdownRenderer.articleTitle("EN", article);
-      should(result).match(/^\* /);
-      should(result).containEql("Markdown Title");
-    });
-
-    it("should handle unpublished article with reason in articleTitle", function() {
-      const article = articleModule.create({
-        title: "Unpublished Article",
-        categoryEN: "--unpublished--",
-        unpublishReason: "Not ready yet",
-        unpublishReference: "PR #123"
-      });
-      const result = htmlRenderer.articleTitle("EN", article);
-      should(result).containEql("Unpublished Article");
-      should(result).containEql("Not ready yet");
-      should(result).containEql("PR #123");
-      should(result).match(/<br>/);
+        it("should render unpublished article title without reason gracefully", function () {
+            const article = articleModule.create({
+                title: "Unpublished No Reason",
+                categoryEN: "--unpublished--",
+            });
+            const result = htmlRenderer.articleTitle("DE", article);
+            should(result).containEql("Unpublished No Reason");
+            should(result).containEql("No Reason given");
+        });
     });
 
-    it("should render unpublished article title without reason gracefully", function() {
-      const article = articleModule.create({
-        title: "Unpublished No Reason",
-        categoryEN: "--unpublished--"
-      });
-      const result = htmlRenderer.articleTitle("DE", article);
-      should(result).containEql("Unpublished No Reason");
-      should(result).containEql("No Reason given");
-    });
-  });
+    describe("Renderer base class abstract methods", function () {
+        let baseRenderer;
 
-  describe("Renderer base class abstract methods", function() {
-    let baseRenderer;
+        before(function () {
+            const blog = {
+                name: "WN000",
+                closeDE: true,
+                getCategories() {
+                    return [];
+                },
+            };
+            baseRenderer = new Renderer(blog);
+        });
 
-    before(function() {
-      const blog = {
-        name: "WN000",
-        closeDE: true,
-        getCategories() {
-          return [];
-        }
-      };
-      baseRenderer = new Renderer(blog);
-    });
+        it("should throw on subtitle()", function () {
+            should.throws(() => baseRenderer.subtitle("DE"), /subtitle\(\) must be implemented by subclass/);
+        });
 
-    it("should throw on subtitle()", function() {
-      should.throws(() => baseRenderer.subtitle("DE"), /subtitle\(\) must be implemented by subclass/);
-    });
+        it("should throw on _containsEmptyArticlesWarning()", function () {
+            should.throws(
+                () => baseRenderer._containsEmptyArticlesWarning("DE"),
+                /_containsEmptyArticlesWarning\(\) must be implemented by subclass/,
+            );
+        });
 
-    it("should throw on _containsEmptyArticlesWarning()", function() {
-      should.throws(
-        () => baseRenderer._containsEmptyArticlesWarning("DE"),
-        /_containsEmptyArticlesWarning\(\) must be implemented by subclass/
-      );
-    });
+        it("should throw on categoryTitle()", function () {
+            should.throws(
+                () => baseRenderer.categoryTitle("DE", { EN: "News", DE: "News" }),
+                /categoryTitle\(\) must be implemented by subclass/,
+            );
+        });
 
-    it("should throw on categoryTitle()", function() {
-      should.throws(
-        () => baseRenderer.categoryTitle("DE", { EN: "News", DE: "News" }),
-        /categoryTitle\(\) must be implemented by subclass/
-      );
-    });
+        it("should throw on _renderArticleStandard()", function () {
+            should.throws(
+                () => baseRenderer._renderArticleStandard("DE", articleModule.create({ markdownDE: "x" })),
+                /_renderArticleStandard\(\) must be implemented by subclass/,
+            );
+        });
 
-    it("should throw on _renderArticleStandard()", function() {
-      should.throws(
-        () => baseRenderer._renderArticleStandard("DE", articleModule.create({ markdownDE: "x" })),
-        /_renderArticleStandard\(\) must be implemented by subclass/
-      );
-    });
+        it("should throw on _renderArticlePicture()", function () {
+            should.throws(
+                () => baseRenderer._renderArticlePicture("DE", articleModule.create({ markdownDE: "x" })),
+                /_renderArticlePicture\(\) must be implemented by subclass/,
+            );
+        });
 
-    it("should throw on _renderArticlePicture()", function() {
-      should.throws(
-        () => baseRenderer._renderArticlePicture("DE", articleModule.create({ markdownDE: "x" })),
-        /_renderArticlePicture\(\) must be implemented by subclass/
-      );
-    });
+        it("should throw on _renderArticleUpcomingEvents()", function () {
+            should.throws(
+                () => baseRenderer._renderArticleUpcomingEvents("DE", articleModule.create({ markdownDE: "x" })),
+                /_renderArticleUpcomingEvents\(\) must be implemented by subclass/,
+            );
+        });
 
-    it("should throw on _renderArticleUpcomingEvents()", function() {
-      should.throws(
-        () => baseRenderer._renderArticleUpcomingEvents("DE", articleModule.create({ markdownDE: "x" })),
-        /_renderArticleUpcomingEvents\(\) must be implemented by subclass/
-      );
-    });
+        it("should throw on _renderArticleUnpublished()", function () {
+            should.throws(
+                () => baseRenderer._renderArticleUnpublished("text", articleModule.create({ title: "x" })),
+                /_renderArticleUnpublished\(\) must be implemented by subclass/,
+            );
+        });
 
-    it("should throw on _renderArticleUnpublished()", function() {
-      should.throws(
-        () => baseRenderer._renderArticleUnpublished("text", articleModule.create({ title: "x" })),
-        /_renderArticleUnpublished\(\) must be implemented by subclass/
-      );
-    });
+        it("should throw on articleTitle()", function () {
+            should.throws(
+                () => baseRenderer.articleTitle("DE", articleModule.create({ title: "x" })),
+                /articleTitle\(\) must be implemented by subclass/,
+            );
+        });
 
-    it("should throw on articleTitle()", function() {
-      should.throws(
-        () => baseRenderer.articleTitle("DE", articleModule.create({ title: "x" })),
-        /articleTitle\(\) must be implemented by subclass/
-      );
-    });
+        it("should throw on _listAroundArticles()", function () {
+            should.throws(
+                () => baseRenderer._listAroundArticles("content"),
+                /_listAroundArticles\(\) must be implemented by subclass/,
+            );
+        });
 
-    it("should throw on _listAroundArticles()", function() {
-      should.throws(
-        () => baseRenderer._listAroundArticles("content"),
-        /_listAroundArticles\(\) must be implemented by subclass/
-      );
-    });
+        it("should throw on _formatTeamString()", function () {
+            should.throws(
+                () => baseRenderer._formatTeamString("team"),
+                /_formatTeamString\(\) must be implemented by subclass/,
+            );
+        });
 
-    it("should throw on _formatTeamString()", function() {
-      should.throws(
-        () => baseRenderer._formatTeamString("team"),
-        /_formatTeamString\(\) must be implemented by subclass/
-      );
+        it("should throw on _generateFrontText()", function () {
+            should.throws(
+                () => baseRenderer._generateFrontText("DE"),
+                /_generateFrontText\(\) must be implemented by subclass/,
+            );
+        });
     });
 
-    it("should throw on _generateFrontText()", function() {
-      should.throws(
-        () => baseRenderer._generateFrontText("DE"),
-        /_generateFrontText\(\) must be implemented by subclass/
-      );
-    });
-  });
+    describe("BlogRenderer factory", function () {
+        it("should map renderer type names case-insensitively", function () {
+            const htmlRenderer = BlogRenderer.createRenderer("hTmL");
+            const mdRenderer = BlogRenderer.createRenderer("markdown");
+            const hugoRenderer = BlogRenderer.createRenderer("HuGo");
 
-  describe("BlogRenderer factory", function() {
-    it("should map renderer type names case-insensitively", function() {
-      const htmlRenderer = BlogRenderer.createRenderer("hTmL");
-      const mdRenderer = BlogRenderer.createRenderer("markdown");
-      const hugoRenderer = BlogRenderer.createRenderer("HuGo");
+            should(htmlRenderer).be.instanceOf(BlogRenderer.HtmlRenderer);
+            should(mdRenderer).be.instanceOf(BlogRenderer.MarkdownRenderer);
+            should(hugoRenderer).be.instanceOf(BlogRenderer.HugoMarkdownRenderer);
+        });
 
-      should(htmlRenderer).be.instanceOf(BlogRenderer.HtmlRenderer);
-      should(mdRenderer).be.instanceOf(BlogRenderer.MarkdownRenderer);
-      should(hugoRenderer).be.instanceOf(BlogRenderer.HugoMarkdownRenderer);
-    });
+        it("should map HUGOMARKDOWN alias", function () {
+            const hugoRenderer = BlogRenderer.createRenderer("hugomarkdown");
+            should(hugoRenderer).be.instanceOf(BlogRenderer.HugoMarkdownRenderer);
+        });
 
-    it("should map HUGOMARKDOWN alias", function() {
-      const hugoRenderer = BlogRenderer.createRenderer("hugomarkdown");
-      should(hugoRenderer).be.instanceOf(BlogRenderer.HugoMarkdownRenderer);
+        it("should throw on unknown renderer type", function () {
+            should.throws(() => BlogRenderer.createRenderer("pdf"), /Unknown renderer type/);
+        });
     });
-
-    it("should throw on unknown renderer type", function() {
-      should.throws(() => BlogRenderer.createRenderer("pdf"), /Unknown renderer type/);
-    });
-  });
 });


### PR DESCRIPTION
Aliases do not have a language code in Hugo.
I have adapted the code manually, it is not tested.