### PR TITLE
fix(blog): credit-sentence fixes — URL-encoded links, apiKeys users excluded

### DIFF
--- a/model/blog.js
+++ b/model/blog.js
@@ -1810,7 +1810,8 @@ function convertLogsToTeamString(logs, lang, users) {
           continue;
         }
         // default the link with the OSM Profile
-        editors[i] = '<a href="https://www.openstreetmap.org/user/' + editors[i] + '">' + editors[i] + "</a>";
+        editors[i] =
+          '<a href="https://www.openstreetmap.org/user/' + encodeURIComponent(editors[i]) + '">' + editors[i] + "</a>";
       }
     }
   }

--- a/model/blog.js
+++ b/model/blog.js
@@ -18,6 +18,7 @@ import logModule from "../model/logModule.js";
 import messageCenter from "../notification/messageCenter.js";
 import userModule from "../model/user.js";
 import translator from "../model/translator.js";
+import { getKnownMigrationUserNames } from "../notification/migrationFilter.js";
 import osmcalLoader from "../model/osmcalLoader.js";
 
 import pgMap from "./pgMap.js";
@@ -1775,11 +1776,16 @@ function convertLogsToTeamString(logs, lang, users) {
   for (const f in translator) {
     apiEditors.push(translator[f].user);
   }
-  // Synthetic users the wp-reconcile migration tooling uses for audit-log
-  // attribution (see wp-reconcile/ scripts) - never real contributors, so
-  // they must not show up in the public credit sentence, same as the
-  // API/translator users above.
-  apiEditors.push("wp-backport", "wp-oldimport");
+  // Migration/API-key users (wp-backport plus every configured apiKeys
+  // value, see notification/migrationFilter.js) - never real contributors,
+  // so they must not show up in the public credit sentence, same as the
+  // API/translator users above. Shares its source of truth with the
+  // notification filter instead of hardcoding a second copy of this list.
+  apiEditors.push(...getKnownMigrationUserNames());
+  // wp-oldimport predates the migration/apiKeys mechanism entirely (the
+  // one-time pre-osmbc bulk import, see createTeamString's comment above)
+  // and isn't attributed through an apiKey, so it's excluded separately.
+  apiEditors.push("wp-oldimport");
   function addEditors(property, min) {
     for (const user in logs[property]) {
       if (logs[property][user] >= min) {

--- a/notification/migrationFilter.js
+++ b/notification/migrationFilter.js
@@ -27,7 +27,12 @@ import config from "../config.js";
 
 export const SYNTHETIC_MIGRATION_USER_NAME = "wp-backport";
 
-function getKnownMigrationUserNames() {
+// Exported so other consumers that need to recognize/exclude migration-style
+// users (e.g. model/blog.js's credit-line byline) build the same set instead
+// of hardcoding their own copy of "which users are migration/API users" -
+// that duplication is exactly how wp-backport once leaked into a byline
+// while already being suppressed here for notifications.
+export function getKnownMigrationUserNames() {
   const apiKeys = config.getValue("apiKeys", { default: {} });
   return new Set([SYNTHETIC_MIGRATION_USER_NAME, ...Object.values(apiKeys)]);
 }
@@ -57,4 +62,4 @@ export function suppressMigrationNotifications(receiver) {
   });
 }
 
-export default { SYNTHETIC_MIGRATION_USER_NAME, suppressMigrationNotifications };
+export default { SYNTHETIC_MIGRATION_USER_NAME, getKnownMigrationUserNames, suppressMigrationNotifications };

--- a/test/model.blog.test.js
+++ b/test/model.blog.test.js
@@ -957,6 +957,26 @@ describe("model/blog", function() {
         });
       });
     });
+    it("excludes any configured apiKeys user (not just the hardcoded wp-backport) from the credit sentence", function(bddone) {
+      // config.test.yaml's apiKeys.testapikey.dataadmin maps to "dataAdmin-TestUser" -
+      // same mechanism notification/migrationFilter.js already uses to keep
+      // API-key-attributed writers out of mail/Slack notifications.
+      async.parallel([
+        function writeAlice(cb) { logModule.log({ user: "Alice", blog: "WN1", oid: "1", property: "reviewCommentEN" }, cb); },
+        function writeDataAdmin(cb) { logModule.log({ user: "dataAdmin-TestUser", blog: "WN1", oid: "2", property: "reviewCommentEN" }, cb); }
+      ], function(err) {
+        should.not.exist(err);
+        blogModule.findOne({ name: "WN1" }, function(err, blog) {
+          should.not.exist(err);
+          blog.createTeamString("EN", function(err, result) {
+            should.not.exist(err);
+            result.should.containEql("Alice");
+            result.should.not.containEql("dataAdmin-TestUser");
+            bddone();
+          });
+        });
+      });
+    });
   });
 
   describe("Helper Functions", function() {

--- a/test/model.blog.test.js
+++ b/test/model.blog.test.js
@@ -10,6 +10,7 @@ import testutil from "./testutil.js";
 import config from "../config.js";
 import logModule from "../model/logModule.js";
 import blogModule from "../model/blog.js";
+import userModule from "../model/user.js";
 import articleModule from "../model/article.js";
 import blogRenderer from "../render/BlogRenderer.js";
 import { ExportLogWriterForTestOnly } from "../notification/exportLogWriter.js";
@@ -935,6 +936,23 @@ describe("model/blog", function() {
             result.should.not.containEql("wp-backport");
             result.should.not.containEql("wp-oldimport");
             bddone();
+          });
+        });
+      });
+    });
+    it("URL-encodes spaces in the OSM username instead of leaving them literal in the href", function(bddone) {
+      userModule.createNewUser({ OSMUser: "Laura Barroso" }, function(err) {
+        should.not.exist(err);
+        logModule.log({ user: "Laura Barroso", blog: "WN1", oid: "1", property: "reviewCommentEN" }, function(err) {
+          should.not.exist(err);
+          blogModule.findOne({ name: "WN1" }, function(err, blog) {
+            should.not.exist(err);
+            blog.createTeamString("EN", function(err, result) {
+              should.not.exist(err);
+              result.should.containEql("https://www.openstreetmap.org/user/Laura%20Barroso");
+              result.should.not.containEql("https://www.openstreetmap.org/user/Laura Barroso");
+              bddone();
+            });
           });
         });
       });


### PR DESCRIPTION
## Summary
- `convertLogsToTeamString()` built the OSM profile link href directly from the raw OSM username, so a username containing a space (e.g. "Laura Barroso") produced a link destination with a literal space, which Turndown's HTML→Markdown conversion then had to wrap in CommonMark's `<...>` syntax — rendering that one author's link inconsistently. Fixed by `encodeURIComponent()`-encoding the username in the href.
- Separately, the migration/API-user exclusion list in `convertLogsToTeamString()` was hardcoded to exactly `"wp-backport"` and `"wp-oldimport"`, out of sync with `notification/migrationFilter.js`, which also suppresses mail/Slack notifications for every username configured under `config`'s `apiKeys` map. Any other apiKeys-attributed writer (e.g. a data admin's automated run) was correctly hidden from notifications but could still leak into the public credit sentence. Fixed by exporting `getKnownMigrationUserNames()` from `migrationFilter.js` and reusing it in `convertLogsToTeamString`, so both filters share one source of truth. `wp-oldimport` predates the apiKeys mechanism and stays excluded separately.

## Test plan
- [x] `test/model.blog.test.js` (`createTeamString`): username-with-space is `%20`-encoded; a configured `apiKeys` user (not just `wp-backport`) is excluded from the credit sentence
- [x] `NODE_ENV=test npx mocha test/model.blog.test.js test/notification.migrationFilter.test.js` — 81 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)